### PR TITLE
fix: show more/show less description in proposal description

### DIFF
--- a/src/components/Post/Tabs/PostDescription.tsx
+++ b/src/components/Post/Tabs/PostDescription.tsx
@@ -15,6 +15,7 @@ import PostReactionBar from '../ActionsBar/Reactionbar/PostReactionBar';
 import ReportButton from '../ActionsBar/ReportButton';
 import ShareButton from '../ActionsBar/ShareButton';
 import SubscriptionButton from '../ActionsBar/SubscriptionButton/SubscriptionButton';
+import styled from 'styled-components';
 
 const CommentsContainer = dynamic(() => import('../Comment/CommentsContainer'), {
 	loading: () => <div>
@@ -38,33 +39,17 @@ interface IPostDescriptionProps {
 const PostDescription: FC<IPostDescriptionProps> = (props) => {
 	const { className, canEdit, id, isEditing, toggleEdit, Sidebar, TrackerButtonComp } = props;
 	const { postData: { content, postType, postIndex, title, post_reactions } } = usePostDataContext();
-	const[showMore, setShowMore] = useState(false);
-	// split content into paragraphs and check the length of each paragraph, if each paragraph is more than 350 characters long, then show the show more button
-	const allParagraph = content.trim()?.split('\n');
-	let truncated = '';
-	for (let i = 0; i < allParagraph.length; i++) {
-		if (allParagraph[i].length > 350) {
-			truncated = allParagraph[i].substring(0, 350) + '...';
-			break;
-		}
-		if (allParagraph[i].startsWith('**')) {
-			truncated = allParagraph[i] + '\n' + allParagraph[i + 2].substring(0,300) + '...';
-			break;
-		}
-	}
-	const isMultipleParagraphs = content.trim()?.split('\n').length > 1;
+	const [showMore, setShowMore] = useState<boolean>(false);
+
 	return (
 		<div className={`${className} mt-4`}>
-			{
-				isMultipleParagraphs?
-					<div className='flex flex-col'>
-						{showMore ?<Markdown md={content} />:<Markdown md={truncated} />}
-						{!showMore ? <p className='text-pink_primary text-start border-none shadow-none cursor-pointer' onClick={() => setShowMore(true)}>Show more</p>
-							:<p className='text-pink_primary text-start border-none shadow-none cursor-pointer' onClick={() => setShowMore(false)}>Show less</p>
-						}
-					</div>
-					:<Markdown md={content} />
+			{content && <Markdown className={`${!showMore && 'clamped'}`} md={content} />}
+			{content.trim().split('\n')?.length > 5 &&
+				<p className='text-pink_primary py-2 cursor-pointer' onClick={() => setShowMore(!showMore)}>
+					{showMore ? 'Show less' : 'Show more'}
+				</p>
 			}
+
 			{/* Actions Bar */}
 			<div id='actions-bar' className={`flex flex-col md:items-center mt-9 ${canEdit && 'flex-col'} md:flex-row mb-8`}>
 				<div className='flex items-center'>
@@ -92,4 +77,12 @@ const PostDescription: FC<IPostDescriptionProps> = (props) => {
 	);
 };
 
-export default PostDescription;
+export default styled(PostDescription)`
+.clamped {
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 5;
+	line-clamp: 5; 
+	-webkit-box-orient: vertical;
+}
+`;


### PR DESCRIPTION
Show more/show less functionality has been added to the proposal description with 5 lines being shown at a time