### PR TITLE
fix: pagination issues

### DIFF
--- a/pages/big-spender/index.tsx
+++ b/pages/big-spender/index.tsx
@@ -2,9 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Pagination } from 'antd';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import { getOnChainPosts, IPostsListingResponse } from 'pages/api/v1/listing/on-chain-posts';
 import { IReferendumV2PostsByStatus } from 'pages/root';
 import React, { FC, useEffect } from 'react';
@@ -20,7 +18,6 @@ import SEOHead from '~src/global/SEOHead';
 import { sortValues } from '~src/global/sortOptions';
 import { IApiResponse, PostOrigin } from '~src/types';
 import { ErrorState } from '~src/ui-components/UIStates';
-import { handlePaginationChange } from '~src/util/handlePaginationChange';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
 	const { page = 1, sortBy = sortValues.NEWEST, filterBy } = query;
@@ -111,17 +108,6 @@ const BigSpender: FC<IBigSpenderProps> = (props) => {
 		setNetwork(props.network);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
-
-	const router = useRouter();
-	const onPaginationChange = (page:number) => {
-		router.push({
-			query:{
-				page
-			}
-		});
-		handlePaginationChange({ limit: LISTING_LIMIT, page });
-	};
-
 	if (error) return <ErrorState errorMessage={error} />;
 
 	if (!posts || Object.keys(posts).length === 0) return null;
@@ -131,16 +117,6 @@ const BigSpender: FC<IBigSpenderProps> = (props) => {
 			trackName={PostOrigin.BIG_SPENDER}
 			posts={posts}
 		/>
-		<div className='flex justify-end mt-6'>
-			<Pagination defaultCurrent={1}
-				pageSize={LISTING_LIMIT}
-				total={posts.all?.data?.count || 0}
-				showSizeChanger={false}
-				hideOnSinglePage={true}
-				onChange={onPaginationChange}
-				responsive={true}
-			/>
-		</div>
 	</>;
 };
 

--- a/pages/big-tipper/index.tsx
+++ b/pages/big-tipper/index.tsx
@@ -2,9 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Pagination } from 'antd';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import { getOnChainPosts, IPostsListingResponse } from 'pages/api/v1/listing/on-chain-posts';
 import { IReferendumV2PostsByStatus } from 'pages/root';
 import React, { FC, useEffect } from 'react';
@@ -20,7 +18,6 @@ import SEOHead from '~src/global/SEOHead';
 import { sortValues } from '~src/global/sortOptions';
 import { IApiResponse, PostOrigin } from '~src/types';
 import { ErrorState } from '~src/ui-components/UIStates';
-import { handlePaginationChange } from '~src/util/handlePaginationChange';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
 	const { page = 1, sortBy = sortValues.NEWEST, filterBy } = query;
@@ -113,16 +110,6 @@ const BigTipper: FC<IBigTipperProps> = (props) => {
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
-	const router = useRouter();
-	const onPaginationChange = (page:number) => {
-		router.push({
-			query:{
-				page
-			}
-		});
-		handlePaginationChange({ limit: LISTING_LIMIT, page });
-	};
-
 	if (error) return <ErrorState errorMessage={error} />;
 
 	if (!posts || Object.keys(posts).length === 0) return null;
@@ -132,16 +119,6 @@ const BigTipper: FC<IBigTipperProps> = (props) => {
 			trackName={PostOrigin.BIG_TIPPER}
 			posts={posts}
 		/>
-		<div className='flex justify-end mt-6'>
-			<Pagination defaultCurrent={1}
-				pageSize={LISTING_LIMIT}
-				total={posts.all?.data?.count || 0}
-				showSizeChanger={false}
-				hideOnSinglePage={true}
-				onChange={onPaginationChange}
-				responsive={true}
-			/>
-		</div>
 	</>;
 };
 

--- a/pages/lease-admin/index.tsx
+++ b/pages/lease-admin/index.tsx
@@ -2,9 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Pagination } from 'antd';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import { getOnChainPosts, IPostsListingResponse } from 'pages/api/v1/listing/on-chain-posts';
 import { IReferendumV2PostsByStatus } from 'pages/root';
 import React, { FC, useEffect } from 'react';
@@ -20,7 +18,6 @@ import SEOHead from '~src/global/SEOHead';
 import { sortValues } from '~src/global/sortOptions';
 import { IApiResponse, PostOrigin } from '~src/types';
 import { ErrorState } from '~src/ui-components/UIStates';
-import { handlePaginationChange } from '~src/util/handlePaginationChange';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
 	const { page = 1, sortBy = sortValues.NEWEST ,filterBy } = query;
@@ -112,17 +109,6 @@ const LeaseAdmin: FC<ILeaseAdminProps> = (props) => {
 		setNetwork(props.network);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
-
-	const router = useRouter();
-	const onPaginationChange = (page:number) => {
-		router.push({
-			query:{
-				page
-			}
-		});
-		handlePaginationChange({ limit: LISTING_LIMIT, page });
-	};
-
 	if (error) return <ErrorState errorMessage={error} />;
 
 	if (!posts || Object.keys(posts).length === 0) return null;
@@ -132,16 +118,6 @@ const LeaseAdmin: FC<ILeaseAdminProps> = (props) => {
 			trackName={PostOrigin.LEASE_ADMIN}
 			posts={posts}
 		/>
-		<div className='flex justify-end mt-6'>
-			<Pagination defaultCurrent={1}
-				pageSize={LISTING_LIMIT}
-				total={posts.all?.data?.count || 0}
-				showSizeChanger={false}
-				hideOnSinglePage={true}
-				onChange={onPaginationChange}
-				responsive={true}
-			/>
-		</div>
 	</>;
 };
 

--- a/pages/medium-spender/index.tsx
+++ b/pages/medium-spender/index.tsx
@@ -2,9 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Pagination } from 'antd';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import { getOnChainPosts, IPostsListingResponse } from 'pages/api/v1/listing/on-chain-posts';
 import { IReferendumV2PostsByStatus } from 'pages/root';
 import React, { FC, useEffect } from 'react';
@@ -20,7 +18,6 @@ import SEOHead from '~src/global/SEOHead';
 import { sortValues } from '~src/global/sortOptions';
 import { IApiResponse, PostOrigin } from '~src/types';
 import { ErrorState } from '~src/ui-components/UIStates';
-import { handlePaginationChange } from '~src/util/handlePaginationChange';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
 	const { page = 1, sortBy = sortValues.NEWEST, filterBy } = query;
@@ -115,17 +112,6 @@ const MediumSpender: FC<IMediumSpenderProps> = (props) => {
 		setNetwork(props.network);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
-
-	const router = useRouter();
-	const onPaginationChange = (page:number) => {
-		router.push({
-			query:{
-				page
-			}
-		});
-		handlePaginationChange({ limit: LISTING_LIMIT, page });
-	};
-
 	if (error) return <ErrorState errorMessage={error} />;
 
 	if (!posts || Object.keys(posts).length === 0) return null;
@@ -135,16 +121,6 @@ const MediumSpender: FC<IMediumSpenderProps> = (props) => {
 			trackName={PostOrigin.MEDIUM_SPENDER}
 			posts={posts}
 		/>
-		<div className='flex justify-end mt-6'>
-			<Pagination defaultCurrent={1}
-				pageSize={LISTING_LIMIT}
-				total={posts.all?.data?.count || 0}
-				showSizeChanger={false}
-				hideOnSinglePage={true}
-				onChange={onPaginationChange}
-				responsive={true}
-			/>
-		</div>
 	</>;
 };
 

--- a/pages/root/index.tsx
+++ b/pages/root/index.tsx
@@ -118,7 +118,6 @@ const Root: FC<IRootProps> = (props) => {
 		setNetwork(props.network);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
-
 	if (error) return <ErrorState errorMessage={error} />;
 
 	if (!posts || Object.keys(posts).length === 0) return null;

--- a/pages/small-spender/index.tsx
+++ b/pages/small-spender/index.tsx
@@ -2,9 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Pagination } from 'antd';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import { getOnChainPosts, IPostsListingResponse } from 'pages/api/v1/listing/on-chain-posts';
 import { IReferendumV2PostsByStatus } from 'pages/root';
 import React, { FC, useEffect } from 'react';
@@ -20,7 +18,6 @@ import SEOHead from '~src/global/SEOHead';
 import { sortValues } from '~src/global/sortOptions';
 import { IApiResponse, PostOrigin } from '~src/types';
 import { ErrorState } from '~src/ui-components/UIStates';
-import { handlePaginationChange } from '~src/util/handlePaginationChange';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
 	const { page = 1, sortBy = sortValues.NEWEST, filterBy } = query;
@@ -113,16 +110,6 @@ const SmallSpender: FC<ISmallSpenderProps> = (props) => {
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
-	const router = useRouter();
-	const onPaginationChange = (page:number) => {
-		router.push({
-			query:{
-				page
-			}
-		});
-		handlePaginationChange({ limit: LISTING_LIMIT, page });
-	};
-
 	if (error) return <ErrorState errorMessage={error} />;
 
 	if (!posts || Object.keys(posts).length === 0) return null;
@@ -132,16 +119,6 @@ const SmallSpender: FC<ISmallSpenderProps> = (props) => {
 			trackName={PostOrigin.SMALL_SPENDER}
 			posts={posts}
 		/>
-		<div className='flex justify-end mt-6'>
-			<Pagination defaultCurrent={1}
-				pageSize={LISTING_LIMIT}
-				total={posts.all?.data?.count || 0}
-				showSizeChanger={false}
-				hideOnSinglePage={true}
-				onChange={onPaginationChange}
-				responsive={true}
-			/>
-		</div>
 	</>;
 };
 

--- a/pages/small-tipper/index.tsx
+++ b/pages/small-tipper/index.tsx
@@ -2,9 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Pagination } from 'antd';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import { getOnChainPosts, IPostsListingResponse } from 'pages/api/v1/listing/on-chain-posts';
 import { IReferendumV2PostsByStatus } from 'pages/root';
 import React, { FC, useEffect } from 'react';
@@ -20,7 +18,6 @@ import SEOHead from '~src/global/SEOHead';
 import { sortValues } from '~src/global/sortOptions';
 import { IApiResponse, PostOrigin } from '~src/types';
 import { ErrorState } from '~src/ui-components/UIStates';
-import { handlePaginationChange } from '~src/util/handlePaginationChange';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
 	const { page = 1, sortBy = sortValues.NEWEST, filterBy } = query;
@@ -112,17 +109,6 @@ const SmallTipper: FC<ISmallTipperProps> = (props) => {
 		setNetwork(props.network);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
-
-	const router = useRouter();
-	const onPaginationChange = (page:number) => {
-		router.push({
-			query:{
-				page
-			}
-		});
-		handlePaginationChange({ limit: LISTING_LIMIT, page });
-	};
-
 	if (error) return <ErrorState errorMessage={error} />;
 
 	if (!posts || Object.keys(posts).length === 0) return null;
@@ -132,16 +118,6 @@ const SmallTipper: FC<ISmallTipperProps> = (props) => {
 			trackName={PostOrigin.SMALL_TIPPER}
 			posts={posts}
 		/>
-		<div className='flex justify-end mt-6'>
-			<Pagination defaultCurrent={1}
-				pageSize={LISTING_LIMIT}
-				total={posts.all?.data?.count || 0}
-				showSizeChanger={false}
-				hideOnSinglePage={true}
-				onChange={onPaginationChange}
-				responsive={true}
-			/>
-		</div>
 	</>;
 };
 

--- a/pages/treasurer/index.tsx
+++ b/pages/treasurer/index.tsx
@@ -2,9 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Pagination } from 'antd';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import { getOnChainPosts, IPostsListingResponse } from 'pages/api/v1/listing/on-chain-posts';
 import { IReferendumV2PostsByStatus } from 'pages/root';
 import React, { FC, useEffect } from 'react';
@@ -20,7 +18,6 @@ import SEOHead from '~src/global/SEOHead';
 import { sortValues } from '~src/global/sortOptions';
 import { IApiResponse, PostOrigin } from '~src/types';
 import { ErrorState } from '~src/ui-components/UIStates';
-import { handlePaginationChange } from '~src/util/handlePaginationChange';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
 	const { page = 1, sortBy = sortValues.NEWEST, filterBy } = query;
@@ -112,17 +109,6 @@ const Treasurer: FC<ITreasurerProps> = (props) => {
 		setNetwork(props.network);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
-
-	const router = useRouter();
-	const onPaginationChange = (page:number) => {
-		router.push({
-			query:{
-				page
-			}
-		});
-		handlePaginationChange({ limit: LISTING_LIMIT, page });
-	};
-
 	if (error) return <ErrorState errorMessage={error} />;
 
 	if (!posts || Object.keys(posts).length === 0) return null;
@@ -132,16 +118,6 @@ const Treasurer: FC<ITreasurerProps> = (props) => {
 			trackName={PostOrigin.TREASURER}
 			posts={posts}
 		/>
-		<div className='flex justify-end mt-6'>
-			<Pagination defaultCurrent={1}
-				pageSize={LISTING_LIMIT}
-				total={posts.all?.data?.count || 0}
-				showSizeChanger={false}
-				hideOnSinglePage={true}
-				onChange={onPaginationChange}
-				responsive={true}
-			/>
-		</div>
 	</>;
 };
 

--- a/pages/whitelisted-caller/index.tsx
+++ b/pages/whitelisted-caller/index.tsx
@@ -2,9 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Pagination } from 'antd';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import { getOnChainPosts, IPostsListingResponse } from 'pages/api/v1/listing/on-chain-posts';
 import { IReferendumV2PostsByStatus } from 'pages/root';
 import React, { FC, useEffect } from 'react';
@@ -20,7 +18,6 @@ import SEOHead from '~src/global/SEOHead';
 import { sortValues } from '~src/global/sortOptions';
 import { IApiResponse, PostOrigin } from '~src/types';
 import { ErrorState } from '~src/ui-components/UIStates';
-import { handlePaginationChange } from '~src/util/handlePaginationChange';
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
 	const { page = 1, sortBy = sortValues.NEWEST, filterBy } = query;
@@ -113,16 +110,6 @@ const WhitelistedCaller: FC<IWhitelistedCallerProps> = (props) => {
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
-	const router = useRouter();
-	const onPaginationChange = (page:number) => {
-		router.push({
-			query:{
-				page
-			}
-		});
-		handlePaginationChange({ limit: LISTING_LIMIT, page });
-	};
-
 	if (error) return <ErrorState errorMessage={error} />;
 
 	if (!posts || Object.keys(posts).length === 0) return null;
@@ -132,16 +119,6 @@ const WhitelistedCaller: FC<IWhitelistedCallerProps> = (props) => {
 			trackName={PostOrigin.WHITELISTED_CALLER}
 			posts={posts}
 		/>
-		<div className='flex justify-end mt-6'>
-			<Pagination defaultCurrent={1}
-				pageSize={LISTING_LIMIT}
-				total={posts.all?.data?.count || 0}
-				showSizeChanger={false}
-				hideOnSinglePage={true}
-				onChange={onPaginationChange}
-				responsive={true}
-			/>
-		</div>
 	</>;
 };
 

--- a/src/components/Listing/Tracks/TrackListingCard.tsx
+++ b/src/components/Listing/Tracks/TrackListingCard.tsx
@@ -112,7 +112,6 @@ const TrackListingCard = ({ className, posts, trackName } : Props) => {
 				type="card"
 				className='ant-tabs-tab-bg-white text-sidebarBlue font-medium'
 			/>
-			{/* Check each tab if there are more than 10 posts, as the pagination is not shown if there are less than 10 posts. */}
 			{
 				(posts?.all?.data?.count||0) > 10  && activeTab === 'All' || (posts?.submitted?.data?.count||0) > 10 && activeTab === 'Submitted' || (posts?.voting?.data?.count||0) > 10 && activeTab === 'Voting' || (posts?.closed?.data?.count||0) > 10 && activeTab === 'Closed' ?
 					<Pagination


### PR DESCRIPTION
The following fixes have been made: 
- When a specific page number has been selected, and the tab is changed, it defaults to page 1
- Pagination added wherever missing
- If there are less than 10 posts per page, pagination component is not shown. 