### PR TITLE
feat: ctrl + click handled

### DIFF
--- a/src/components/Gov2Home/Gov2LatestActivity/AllGov2PostsTable.tsx
+++ b/src/components/Gov2Home/Gov2LatestActivity/AllGov2PostsTable.tsx
@@ -95,8 +95,8 @@ const AllGov2PostsTable: FC<IAllGov2PostsTableProps> = ({ posts, error }) => {
 		if(!rowData.origin) {
 			path = 'post';
 		}
-		if (typeof window !== 'undefined' && (event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
-			window.open(`/${path}/${rowData.post_id}`, '_blank');
+		if ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
+			window?.open(`/${path}/${rowData.post_id}`, '_blank');
 		} else {
 			router.push(`/${path}/${rowData.post_id}`);
 		}

--- a/src/components/Gov2Home/Gov2LatestActivity/AllGov2PostsTable.tsx
+++ b/src/components/Gov2Home/Gov2LatestActivity/AllGov2PostsTable.tsx
@@ -90,12 +90,16 @@ interface IAllGov2PostsTableProps {
 const AllGov2PostsTable: FC<IAllGov2PostsTableProps> = ({ posts, error }) => {
 	const router = useRouter();
 
-	function gotoPost(rowData: IPostsRowData){
+	function gotoPost(rowData: IPostsRowData): void{
 		let path = 'referenda';
 		if(!rowData.origin) {
 			path = 'post';
 		}
-		router.push(`/${path}/${rowData.post_id}`);
+		if (typeof window !== 'undefined' && (event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
+			window.open(`/${path}/${rowData.post_id}`, '_blank');
+		} else {
+			router.push(`/${path}/${rowData.post_id}`);
+		}
 	}
 
 	//error state
@@ -136,11 +140,16 @@ const AllGov2PostsTable: FC<IAllGov2PostsTableProps> = ({ posts, error }) => {
 		return (
 			<>
 				<div className='hidden lg:block'>
-					<PopulatedLatestActivity columns={columns} tableData={tableData} onClick={(rowData) => gotoPost(rowData)} />
+					<PopulatedLatestActivity columns={columns} tableData={tableData}
+						// modify the tableData to add the onClick event
+						onClick={(rowData) => gotoPost(rowData)}
+					/>
 				</div>
 
 				<div className="block lg:hidden h-[520px] overflow-y-auto">
-					<Gov2PopulatedLatestActivityCard tableData={tableData} onClick={(rowData) => gotoPost(rowData)} />
+					<Gov2PopulatedLatestActivityCard tableData={tableData}
+						onClick={(rowData) => gotoPost(rowData)}
+					/>
 				</div>
 			</>
 		);

--- a/src/components/Gov2Home/Gov2LatestActivity/TrackPostsTable.tsx
+++ b/src/components/Gov2Home/Gov2LatestActivity/TrackPostsTable.tsx
@@ -77,8 +77,8 @@ const TrackPostsTable: FC<ITrackPostsTableProps> = ({ posts, error }) => {
 
 	function gotoPost(rowData: IPostsRowData){
 		if(rowData.origin) {
-			if (typeof window !== 'undefined' && (event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
-				window.open(`/referenda/${rowData.post_id}`, '_blank');
+			if ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
+				window?.open(`/referenda/${rowData.post_id}`, '_blank');
 			} else {
 				router.push(`/referenda/${rowData.post_id}`);
 			}

--- a/src/components/Gov2Home/Gov2LatestActivity/TrackPostsTable.tsx
+++ b/src/components/Gov2Home/Gov2LatestActivity/TrackPostsTable.tsx
@@ -77,7 +77,11 @@ const TrackPostsTable: FC<ITrackPostsTableProps> = ({ posts, error }) => {
 
 	function gotoPost(rowData: IPostsRowData){
 		if(rowData.origin) {
-			router.push(`/referenda/${rowData.post_id}`);
+			if (typeof window !== 'undefined' && (event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
+				window.open(`/referenda/${rowData.post_id}`, '_blank');
+			} else {
+				router.push(`/referenda/${rowData.post_id}`);
+			}
 		}
 	}
 

--- a/src/components/Home/LatestActivity/PostsTable.tsx
+++ b/src/components/Home/LatestActivity/PostsTable.tsx
@@ -89,8 +89,8 @@ const PostsTable: FC<IPostsTableProps> = ({ posts, error, columns, type, count }
 				onClick={(rowData) => {
 					const firestoreProposalType = getFirestoreProposalType(['discussions', 'grants'].includes(rowData.type) ? `${rowData.type.charAt(0).toUpperCase()}${rowData.type.slice(1)}` :  rowData.type);
 					const link = getSinglePostLinkFromProposalType(firestoreProposalType as ProposalType);
-					if (typeof window !== 'undefined' && (event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
-						window.open(`/${link}/${rowData.post_id}`, '_blank');
+					if ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
+						window?.open(`/${link}/${rowData.post_id}`, '_blank');
 					} else {
 						router.push(`/${link}/${rowData.post_id}`);
 					}
@@ -104,8 +104,8 @@ const PostsTable: FC<IPostsTableProps> = ({ posts, error, columns, type, count }
 				onClick={(rowData) => {
 					const firestoreProposalType = getFirestoreProposalType(['discussions', 'grants'].includes(rowData.type) ? `${rowData.type.charAt(0).toUpperCase()}${rowData.type.slice(1)}` :  rowData.type);
 					const link = getSinglePostLinkFromProposalType(firestoreProposalType as ProposalType);
-					if (typeof window !== 'undefined' && (event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
-						window.open(`/${link}/${rowData.post_id}`, '_blank');
+					if ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
+						window?.open(`/${link}/${rowData.post_id}`, '_blank');
 					} else {
 						router.push(`/${link}/${rowData.post_id}`);
 					}

--- a/src/components/Home/LatestActivity/PostsTable.tsx
+++ b/src/components/Home/LatestActivity/PostsTable.tsx
@@ -89,7 +89,11 @@ const PostsTable: FC<IPostsTableProps> = ({ posts, error, columns, type, count }
 				onClick={(rowData) => {
 					const firestoreProposalType = getFirestoreProposalType(['discussions', 'grants'].includes(rowData.type) ? `${rowData.type.charAt(0).toUpperCase()}${rowData.type.slice(1)}` :  rowData.type);
 					const link = getSinglePostLinkFromProposalType(firestoreProposalType as ProposalType);
-					router.push(`/${link}/${rowData.post_id}`);
+					if (typeof window !== 'undefined' && (event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
+						window.open(`/${link}/${rowData.post_id}`, '_blank');
+					} else {
+						router.push(`/${link}/${rowData.post_id}`);
+					}
 				}}
 			/>
 		</div>
@@ -100,7 +104,11 @@ const PostsTable: FC<IPostsTableProps> = ({ posts, error, columns, type, count }
 				onClick={(rowData) => {
 					const firestoreProposalType = getFirestoreProposalType(['discussions', 'grants'].includes(rowData.type) ? `${rowData.type.charAt(0).toUpperCase()}${rowData.type.slice(1)}` :  rowData.type);
 					const link = getSinglePostLinkFromProposalType(firestoreProposalType as ProposalType);
-					router.push(`/${link}/${rowData.post_id}`);
+					if (typeof window !== 'undefined' && (event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
+						window.open(`/${link}/${rowData.post_id}`, '_blank');
+					} else {
+						router.push(`/${link}/${rowData.post_id}`);
+					}
 				}}
 			/>
 		</div>


### PR DESCRIPTION
On clicking a post from the overview section, it open on a new page when `ctrl + click` is used, else it will open on the same page