### PR TITLE
Fix/kr/post history

### DIFF
--- a/pages/api/v1/posts/on-chain-post.ts
+++ b/pages/api/v1/posts/on-chain-post.ts
@@ -257,6 +257,9 @@ const getAndSetNewData = async (params: IParams) => {
 							if(data.gov_type){
 								newData.gov_type = data?.gov_type;
 							}
+							if(data?.history){
+								newData.history = data?.history ? data.history.map((item: any) => { return { ...item, created_at: item?.created_at?.toDate ? item?.created_at.toDate() : item?.created_at };}) : [];
+							}
 						}
 					}
 					if (docRefMap[path]) {
@@ -739,7 +742,6 @@ export async function getOnChainPost(params: IGetOnChainPostParams) : Promise<IA
 			}
 
 		}
-		const history = postData?.history ? postData?.history.map((item: any) => { return { ...item, created_at: item?.created_at?.toDate ? item?.created_at.toDate() : item?.created_at };}) : [];
 
 		const post: IPostResponse = {
 			announcement: postData?.announcement,
@@ -764,7 +766,6 @@ export async function getOnChainPost(params: IGetOnChainPostParams) : Promise<IA
 			ended_at_block: postData?.endedAtBlock,
 			fee: postData?.fee,
 			hash: postData?.hash || preimage?.hash,
-			history,
 			identity: postData?.identity || null,
 			last_edited_at: undefined,
 			member_count: postData?.threshold?.value,
@@ -923,6 +924,7 @@ export async function getOnChainPost(params: IGetOnChainPostParams) : Promise<IA
 			// Populate firestore post data into the post object
 			if (data && post) {
 				post.summary = data.summary;
+				post.history= data?.history;
 				post.topic = getTopicFromFirestoreData(data, strProposalType);
 				post.content = data.content;
 				if (!post.proposer) {

--- a/pages/api/v1/posts/on-chain-post.ts
+++ b/pages/api/v1/posts/on-chain-post.ts
@@ -924,7 +924,7 @@ export async function getOnChainPost(params: IGetOnChainPostParams) : Promise<IA
 			// Populate firestore post data into the post object
 			if (data && post) {
 				post.summary = data.summary;
-				post.history= data?.history;
+				post.history= data?.history || [];
 				post.topic = getTopicFromFirestoreData(data, strProposalType);
 				post.content = data.content;
 				if (!post.proposer) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- **Refactor**: Updated the `getAndSetNewData` and `getOnChainPost` functions in `pages/api/v1/posts/on-chain-post.ts`. The changes improve how post history data is handled, ensuring that it's correctly assigned whether or not `data.history` exists. This enhances the reliability of post history retrieval and assignment, providing a more consistent user experience when viewing post histories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Modified `getAndSetNewData` function to handle the presence of `data.history` correctly, ensuring that the `history` property in `newData` is populated with a modified version of the `data.history` array.
- Refactor: Updated `getOnChainPost` function to directly assign the value of `data.history` to the `post.history` property or assign an empty array if it doesn't exist. This improves code readability and removes unnecessary variable assignment.

<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->