### PR TITLE
fix: :bug: vote modal fixes

### DIFF
--- a/src/components/Post/GovernanceSideBar/Referenda/Modal/VoteSuccessModal.tsx
+++ b/src/components/Post/GovernanceSideBar/Referenda/Modal/VoteSuccessModal.tsx
@@ -219,7 +219,7 @@ const VoteInitiatedModal = ({
 							{' '}
                             Conviction:
 							<span className='text-bodyBlue font-medium'>
-								{conviction}x
+								{conviction === 0 ? '0.1': conviction}x
 							</span>{' '}
 						</div>
 						<div className='flex h-[21px] gap-[14px] text-sm text-lightBlue font-normal'>

--- a/src/components/Post/GovernanceSideBar/Referenda/Modal/VoteSuccessModal.tsx
+++ b/src/components/Post/GovernanceSideBar/Referenda/Modal/VoteSuccessModal.tsx
@@ -219,7 +219,7 @@ const VoteInitiatedModal = ({
 							{' '}
                             Conviction:
 							<span className='text-bodyBlue font-medium'>
-								{conviction === 0 ? '0.1': conviction}x
+								{conviction || '0.1'}x
 							</span>{' '}
 						</div>
 						<div className='flex h-[21px] gap-[14px] text-sm text-lightBlue font-normal'>

--- a/src/components/Post/GovernanceSideBar/Referenda/VoteReferendum.tsx
+++ b/src/components/Post/GovernanceSideBar/Referenda/VoteReferendum.tsx
@@ -822,7 +822,7 @@ const VoteReferendum = ({ className, referendumId, onAccountChange, lastVote, se
 					</Spin>
 				</>
 			</Modal>
-			<VoteInitiatedModal title={multisig ? 'Voting with Polkasafe Multisig initiated':'Voting' }  vote={vote} balance={voteValues.totalVoteValue} open={successModal} setOpen={setSuccessModal}  address={address} multisig={multisig ? multisig : ''} conviction={conviction}  votedAt={ dayjs().format('HH:mm, Do MMMM YYYY')} ayeVoteValue={voteValues.ayeVoteValue} nayVoteValue={voteValues.nayVoteValue} abstainVoteValue={voteValues.abstainVoteValue} icon={multisig ? <MultisigSuccessIcon/>: <SuccessIcon/>}/>
+			<VoteInitiatedModal title={multisig ? 'Voting with Polkasafe Multisig initiated': 'Voted Successfully' }  vote={vote} balance={voteValues.totalVoteValue} open={successModal} setOpen={setSuccessModal}  address={address} multisig={multisig ? multisig : ''} conviction={conviction}  votedAt={ dayjs().format('HH:mm, Do MMMM YYYY')} ayeVoteValue={voteValues.ayeVoteValue} nayVoteValue={voteValues.nayVoteValue} abstainVoteValue={voteValues.abstainVoteValue} icon={multisig ? <MultisigSuccessIcon/>: <SuccessIcon/>}/>
 		</div>
 	</>;
 

--- a/src/components/Post/GovernanceSideBar/index.tsx
+++ b/src/components/Post/GovernanceSideBar/index.tsx
@@ -665,7 +665,7 @@ const GovernanceSideBar: FC<IGovernanceSidebarProps> = (props) => {
 					<Tooltip placement="bottom"  title="Conviction"  color={'#E5007A'} className='ml-[-5px]'>
 						<span title='Conviction'>
 							<ConvictionIcon className='mr-1'/>
-							{lockPeriod}x
+							{lockPeriod || '0.1'}x
 						</span>
 					</Tooltip>
 				</div>


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the `VoteInitiatedModal` component to display a default conviction value of '0.1' if the `conviction` prop is missing or falsy, ensuring correct visual representation for better user feedback.
- Bug Fix: Changed the title of a modal component in the `VoteReferendum` component from "Voting with Polkasafe Multisig initiated" to "Voted Successfully" for more accurate information to the user.
- Bug Fix: Added a default value of '0.1' for the `lockPeriod` variable in the `GovernanceSideBar` component to ensure correct rendering of the `ConvictionIcon` component even when `lockPeriod` is not provided.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Updated the visual representation of the "Conviction" value in the VoteSuccessModal component to display "0.1" when the conviction value is 0, enhancing user understanding.
- Style: Changed the title of the modal component in VoteReferendum.tsx to "Voted Successfully", improving user feedback after voting.
- Refactor: Added default values for `lockPeriod` and `conviction` in GovernanceSideBar and VoteInitiatedModal components respectively, ensuring consistent display even when these values are undefined or null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->