### PR TITLE
fix: picasso issuance

### DIFF
--- a/src/components/Post/GovernanceSideBar/Referenda/ReferendumV2VoteInfo.tsx
+++ b/src/components/Post/GovernanceSideBar/Referenda/ReferendumV2VoteInfo.tsx
@@ -47,9 +47,15 @@ const ReferendumV2VoteInfo: FC<IReferendumV2VoteInfoProps> = ({ className, tally
 		if (!api || !apiReady) return;
 
 		(async () => {
-			const totalIssuance = await api.query.balances.totalIssuance();
-			const inactiveIssuance = await api.query.balances.inactiveIssuance();
-			setActiveIssuance(totalIssuance.sub(inactiveIssuance));
+			if (network === 'picasso') {
+				const totalIssuance = await api.query.openGovBalances.totalIssuance();
+				const inactiveIssuance = await api.query.openGovBalances.inactiveIssuance();
+				setActiveIssuance((totalIssuance as any).sub(inactiveIssuance));
+			} else {
+				const totalIssuance = await api.query.balances.totalIssuance();
+				const inactiveIssuance = await api.query.balances.inactiveIssuance();
+				setActiveIssuance(totalIssuance.sub(inactiveIssuance));
+			}
 		})();
 
 		if (['confirmed', 'executed', 'timedout', 'cancelled', 'rejected', 'executionfailed'].includes(status.toLowerCase())) {
@@ -90,7 +96,7 @@ const ReferendumV2VoteInfo: FC<IReferendumV2VoteInfoProps> = ({ className, tally
 		})();
 		setIsLoading(false);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [status, api, apiReady]);
+	}, [status, api, apiReady, network]);
 
 	return (
 		<>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Updated the `ReferendumV2VoteInfo` component to correctly handle different network types. The component now uses appropriate queries based on the network type (`picasso` or other networks) to retrieve total and inactive issuance data, ensuring accurate calculation of active issuance. This change enhances the reliability of data displayed to users across different networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->