### PR TITLE
fix/loginModalErrStateDarkTheme

### DIFF
--- a/src/components/Login/Web2Login.tsx
+++ b/src/components/Login/Web2Login.tsx
@@ -38,7 +38,7 @@ const WalletButtons = dynamic(() => import('./WalletButtons'), {
 
 const Container = styled.article`
 	.changeColor .ant-alert-message {
-		color: var(--bodyBlue);
+		color: #1677ff;
 	}
 `;
 
@@ -200,7 +200,7 @@ const Web2Login: FC<Props> = ({ className, walletError, onWalletSelect, setLogin
 					description='No web 3 account integration could be found. To be able to use this feature, visit this page on a computer with polkadot-js extension.'
 					type='info'
 					showIcon
-					className='changeColor  mx-8 mb-5 text-bodyBlue dark:text-blue-dark-high'
+					className='changeColor  mx-8 mb-5 text-bodyBlue dark:text-white dark:bg-[var(--inactiveIconDark)]'
 				/>
 			)}
 			{walletError && (

--- a/src/components/OpenGovTreasuryProposal/DecisionDepositCard.tsx
+++ b/src/components/OpenGovTreasuryProposal/DecisionDepositCard.tsx
@@ -448,7 +448,7 @@ const DecisionDepositCard = ({ className, trackName }: Props) => {
 								description='No web 3 account integration could be found. To be able to use this feature, visit this page on a computer with polkadot-js extension.'
 								type='info'
 								showIcon
-								className='changeColor text-blue-light-high dark:text-blue-dark-high'
+								className='changeColor text-blue-light-high dark:text-white dark:bg-[var(--inactiveIconDark)]'
 							/>
 						)}
 

--- a/src/components/Signup/Web2Signup.tsx
+++ b/src/components/Signup/Web2Signup.tsx
@@ -39,7 +39,7 @@ const WalletButtons = dynamic(() => import('~src/components/Login/WalletButtons'
 
 const Container = styled.article`
 	.changeColor .ant-alert-message {
-		color: ${(props) => (props.theme === 'dark' ? 'white' : '#243a57')} !important;
+		color: ${(props) => (props.theme === 'dark' ? '#1677ff' : '#243a57')} !important;
 	}
 `;
 interface Props {
@@ -200,7 +200,7 @@ const Web2Signup: FC<Props> = ({ className, walletError, onWalletSelect, isModal
 						description='No web 3 account integration could be found. To be able to use this feature, visit this page on a computer with polkadot-js extension.'
 						type='info'
 						showIcon
-						className='changeColor px-8 text-[#243A57] dark:text-blue-dark-high'
+						className='changeColor px-8 text-[#243A57] dark:text-white dark:bg-[var(--inactiveIconDark)]'
 					/>
 				)}
 				{walletError && (

--- a/src/ui-components/AddressConnectModal.tsx
+++ b/src/ui-components/AddressConnectModal.tsx
@@ -505,7 +505,7 @@ const AddressConnectModal = ({
 							}
 							type='info'
 							showIcon
-							className='changeColor text-md mt-6 rounded-[4px] text-bodyBlue dark:text-blue-dark-high'
+							className='changeColor text-md mt-6 rounded-[4px] text-bodyBlue dark:text-white dark:bg-[var(--inactiveIconDark)]'
 						/>
 					)}
 					<Form


### PR DESCRIPTION
### When switching from light mode to dark mode, the alert box did not change according to the theme.



<img width="1470" alt="Screenshot 2023-11-21 at 11 43 46 AM" src="https://github.com/polkassembly/polkassembly/assets/111236747/0f1e1ea3-b3ef-4dd7-9c32-fb6db7ad7a88">
<img width="1470" alt="Screenshot 2023-11-21 at 1 10 52 PM" src="https://github.com/polkassembly/polkassembly/assets/111236747/2c0eaab4-2dcc-4eaf-9f7b-0a6f346da041">

