### PR TITLE
fix:Comment and reply padding issue

### DIFF
--- a/src/components/Post/Comment/Comment.tsx
+++ b/src/components/Post/Comment/Comment.tsx
@@ -98,7 +98,7 @@ export const Comment: FC<ICommentProps> = (props) => {
 			/>
 			<div className='w-full overflow-hidden'>
 				<CreationLabel
-					className='creation-label comment-modal mt-0 rounded-t-md bg-comment_bg px-0 py-2 pt-4 dark:bg-[#141416] md:px-4'
+					className='creation-label comment-modal mt-0 rounded-t-md bg-comment_bg px-2 py-2 pt-4 dark:bg-[#141416] md:px-4'
 					created_at={created_at}
 					defaultAddress={comment.proposer}
 					username={comment.username}

--- a/src/components/Post/Comment/Reply.tsx
+++ b/src/components/Post/Comment/Reply.tsx
@@ -50,7 +50,7 @@ export const Reply = ({ className, commentId, reply, userName, comment, isSubsqu
 			/>
 			<div className='comment-box'>
 				<CreationLabel
-					className='reply-user-container -mt-1 rounded-t-md px-0 py-2 pt-4 dark:bg-[#141416] md:px-4'
+					className='reply-user-container -mt-1 rounded-t-md px-2 py-2 pt-4 dark:bg-[#141416] md:px-4'
 					created_at={created_at}
 					defaultAddress={proposer}
 					username={username}


### PR DESCRIPTION
Comment padding issue on small screen
Before ->
<img width="427" alt="Screenshot 2023-12-03 at 6 55 09 PM" src="https://github.com/polkassembly/polkassembly/assets/111236747/c68b9c77-2ec1-4fd7-a3eb-fdfbd1338614">
After ->
<img width="431" alt="Screenshot 2023-12-03 at 6 54 40 PM" src="https://github.com/polkassembly/polkassembly/assets/111236747/ff1e13b2-ade1-428b-870c-a583987fe2b2">
