### PR TITLE
fix:threshold and summary pie chart overflow issue

### DIFF
--- a/src/components/Post/GovernanceSideBar/Modal/VoteData/ThresholdGraph.tsx
+++ b/src/components/Post/GovernanceSideBar/Modal/VoteData/ThresholdGraph.tsx
@@ -67,7 +67,7 @@ const ThresholdGraph: FC<IThresholdGraph> = (props) => {
 				{curvesError ? (
 					<p className='text-center font-medium text-red-500'>{curvesError}</p>
 				) : (
-					<section className={`${forGovSidebar ? 'ml-[-6px] w-[350px]' : 'ml-0 w-[400px]'}`}>
+					<section className={`${forGovSidebar ? 'ml-[-6px] w-[265px] min-[410px]:w-[340px]' : 'ml-0 w-[400px]'}`}>
 						<article>
 							<Chart.Line
 								className='h-full w-full'

--- a/src/components/Post/GovernanceSideBar/Referenda/RefV2ThresholdData.tsx
+++ b/src/components/Post/GovernanceSideBar/Referenda/RefV2ThresholdData.tsx
@@ -70,7 +70,7 @@ const RefV2ThresholdData: FC<IRefV2ThresholdDataProps> = ({ className, setOpen, 
 									forGovSidebar={true}
 								/>
 							</div>
-							<div className='mt-4 grid grid-cols-2 gap-x-5'>
+							<div className='mt-4 grid gap-x-5 min-[410px]:grid-cols-2'>
 								<div className='col-span-1 flex flex-col gap-x-0'>
 									<span className='flex justify-between gap-x-2 text-xs font-medium text-bodyBlue dark:text-blue-dark-high'>
 										<span className='flex gap-[6px] '>

--- a/src/ui-components/VoteProgress.tsx
+++ b/src/ui-components/VoteProgress.tsx
@@ -84,7 +84,7 @@ const VoteProgress: FC<IVoteProgressProps> = ({ ayeVotes, className, nayVotes, a
 		<div className={`${className} relative -mt-7 flex items-end justify-center gap-x-2`}>
 			<div className='mb-10 flex flex-col justify-center'>
 				<span className='text-[20px] font-semibold leading-6 text-[#2ED47A] dark:text-[#64A057]'>{isAyeNaN ? 50 : ayePercent.toFixed(1)}%</span>
-				<span className='text-xs font-medium leading-[18px] tracking-[0.01em] text-[#485F7D] dark:text-blue-dark-medium dark:text-blue-dark-medium'>Aye</span>
+				<span className='text-xs font-medium leading-[18px] tracking-[0.01em] text-[#485F7D] dark:text-blue-dark-medium'>Aye</span>
 			</div>
 			{/* {
 				turnoutPercentage?
@@ -98,7 +98,7 @@ const VoteProgress: FC<IVoteProgressProps> = ({ ayeVotes, className, nayVotes, a
 			} */}
 			<>
 				<PieChart
-					className='w-[60%]'
+					className='w-[47%] xl:w-[60%]'
 					center={[50, 75]}
 					startAngle={-180}
 					lengthAngle={180}
@@ -112,7 +112,7 @@ const VoteProgress: FC<IVoteProgressProps> = ({ ayeVotes, className, nayVotes, a
 			</>
 			<div className='mb-10 flex flex-col justify-center'>
 				<span className='text-[20px] font-semibold leading-6 text-[#E84865] dark:text-[#BD2020]'>{isNayNaN ? 50 : nayPercent.toFixed(1)}%</span>
-				<span className='text-xs font-medium leading-[18px] tracking-[0.01em] text-[#485F7D] dark:text-blue-dark-medium dark:text-blue-dark-medium'>Nay</span>
+				<span className='text-xs font-medium leading-[18px] tracking-[0.01em] text-[#485F7D] dark:text-blue-dark-medium'>Nay</span>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
### fixed the issue of overflow of summary and threshold chart on small and large screen 
<img width="327" alt="Screenshot 2023-12-03 at 10 14 06 PM" src="https://github.com/polkassembly/polkassembly/assets/111236747/e066bdbd-e8f9-4c4a-82ef-4ad715830904">
