### PR TITLE
fix: the gif icon dark mode focus issue

### DIFF
--- a/src/ui-components/TextEditor.tsx
+++ b/src/ui-components/TextEditor.tsx
@@ -36,7 +36,7 @@ interface ITextEditorProps {
 
 const gifSVGData = `<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 512.000000 512.000000">
 <g transform="translate(0.000000,512.000000) scale(0.100000,-0.100000)"
-fill="#000000" stroke="none">
+fill-rule="evenodd" stroke="none">
 <path d="M830 5104 c-42 -18 -86 -58 -108 -99 -15 -27 -17 -109 -20 -871 l-3
 -842 -92 -4 c-112 -5 -179 -32 -235 -92 -81 -88 -77 -39 -77 -946 0 -801 0
 -805 21 -851 54 -116 140 -169 291 -177 l92 -5 3 -536 c3 -588 1 -562 65 -623


### PR DESCRIPTION
<img width="807" alt="Screenshot 2023-12-04 at 10 44 52 AM" src="https://github.com/polkassembly/polkassembly/assets/111236747/86e609f2-8b43-47a1-aa0a-327ca65ed865">
<img width="785" alt="Screenshot 2023-12-04 at 10 45 21 AM" src="https://github.com/polkassembly/polkassembly/assets/111236747/ab291c7c-a840-43ab-8e6d-0279c8bfddb5">
