### PR TITLE
fix:Dark theme issue in fancy editor

### DIFF
--- a/src/components/ContentForm.tsx
+++ b/src/components/ContentForm.tsx
@@ -3,7 +3,6 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Form } from 'antd';
-import { useTheme } from 'next-themes';
 import React, { useState } from 'react';
 import TextEditor from '~src/ui-components/TextEditor';
 
@@ -40,7 +39,6 @@ const ContentForm = ({ className, height, onChange, value, autofocus = false }: 
 		errorMsg: null,
 		validateStatus: 'success'
 	});
-	const { resolvedTheme: theme } = useTheme();
 
 	const onChangeWrapper = (content: string) => {
 		const validationStatus = validateContent(content);
@@ -62,7 +60,6 @@ const ContentForm = ({ className, height, onChange, value, autofocus = false }: 
 				help={validationStatus.errorMsg}
 			>
 				<TextEditor
-					theme={theme}
 					name='content'
 					value={value}
 					height={height}

--- a/src/ui-components/TextEditor.tsx
+++ b/src/ui-components/TextEditor.tsx
@@ -15,6 +15,7 @@ import { algolia_client } from '~src/components/Search';
 import MarkdownEditor from './MarkdownEditor';
 import { SwapOutlined } from '@ant-design/icons';
 import { CloseIcon } from './CustomIcons';
+import { useTheme } from 'next-themes';
 
 const converter = new showdown.Converter({
 	simplifiedAutoLink: true,
@@ -101,12 +102,13 @@ img {
 `;
 
 const TextEditor: FC<ITextEditorProps> = (props) => {
-	const { className, height, onChange, isDisabled, value, name, autofocus = false, theme } = props;
+	const { className, height, onChange, isDisabled, value, name, autofocus = false } = props;
 
 	const [loading, setLoading] = useState(true);
 	const ref = useRef<Editor | null>(null);
 	const [isModalVisible, setIsModalVisible] = useState(false);
 	const [mdEditor, setMdEditor] = useState<boolean>(true);
+	const { resolvedTheme: theme } = useTheme();
 
 	useEffect(() => {
 		//if value is a link with a username it it, shift caret position to the end of the text
@@ -116,6 +118,7 @@ const TextEditor: FC<ITextEditorProps> = (props) => {
 		ref.current?.editor?.selection.setCursorLocation(ref.current?.editor?.getBody(), 1);
 		ref.current?.editor?.focus();
 	}, [value]);
+	useEffect(() => {}, [theme]);
 
 	function handleEditorChange() {
 		// if it's being changed to md editor
@@ -178,6 +181,7 @@ const TextEditor: FC<ITextEditorProps> = (props) => {
 					>
 						<div className={`${loading && 'invisible'}`}>
 							<Editor
+								key={theme}
 								onPaste={(e) => {
 									e.stopPropagation();
 									e.preventDefault();


### PR DESCRIPTION
### Fancy editor component in comment box not re rendering when toggling the theme 
Before -> 
[screen-capture (28).webm](https://github.com/polkassembly/polkassembly/assets/111236747/6c5fc90f-689b-4713-a2a0-7a52e8afc9ff)
After ->
[screen-capture (27).webm](https://github.com/polkassembly/polkassembly/assets/111236747/6ba16862-086d-45c1-b2ef-d32f4ea1ad17)

