### PR TITLE
fix:Fancy Editor Clipboard text on paste issue fixed

### DIFF
--- a/src/ui-components/TextEditor.tsx
+++ b/src/ui-components/TextEditor.tsx
@@ -185,8 +185,9 @@ const TextEditor: FC<ITextEditorProps> = (props) => {
 								onPaste={(e) => {
 									e.stopPropagation();
 									e.preventDefault();
-									const content = e.clipboardData?.getData('text/html') || '';
+									let content = e.clipboardData?.getData('text/html') || '';
 									const caretPosition = ref.current?.editor?.selection.getRng();
+									content = content.replace(/color\s*:\s*[^;{}]+[;}]/gi, '').replace(/background-color\s*:\s*[^;{}]+[;}]/gi, '');
 									const sanitisedContent = content.replace(/\\n/g, '\n'); // req. for subsquare style md
 									const parsed_content = converter.makeHtml(sanitisedContent);
 									ref.current?.editor?.insertContent(parsed_content || sanitisedContent, { format: 'html', caretPosition });


### PR DESCRIPTION
### Fancy Editor Clipboard text on paste issue fixed
Before->
<img width="1470" alt="Screenshot 2023-12-07 at 10 17 54 PM" src="https://github.com/polkassembly/polkassembly/assets/111236747/1a54e776-cfdc-4328-b767-b535cb66b795">

After ->
<img width="1468" alt="Screenshot 2023-12-07 at 10 17 33 PM" src="https://github.com/polkassembly/polkassembly/assets/111236747/93be4e14-3279-4127-bc17-21f7a5431f02">
