### PR TITLE
fix/ cmd or control + k button disable when focus is on Text Editor

### DIFF
--- a/src/ui-components/SearchBar.tsx
+++ b/src/ui-components/SearchBar.tsx
@@ -29,6 +29,8 @@ const SearchBar: FC<ISearchBarProps> = (props) => {
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
 			if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+				if (event.target instanceof HTMLTextAreaElement && event.target.classList.contains('mde-text')) return;
+				if (event.target instanceof HTMLInputElement && event.target.classList.contains('tox-textfield')) return;
 				setOpen((prev) => !prev);
 			}
 		};


### PR DESCRIPTION
### Fix Search bar component opens on pressing control or cmd + k button
[screen-capture (4).webm](https://github.com/polkassembly/polkassembly/assets/111236747/440a519a-8e17-49a4-ad9f-086ccd81e557)
