### PR TITLE
show block time as singular when it's just 1 min, hr, or day left

### DIFF
--- a/src/components/Listing/Tracks/AboutTrackCard.tsx
+++ b/src/components/Listing/Tracks/AboutTrackCard.tsx
@@ -129,13 +129,14 @@ export const blocksToRelevantTime = (network: string, blocks: number): string =>
 		text = 'min';
 	} else if (blockSeconds > 3600 && blockSeconds < 86400) {
 		divisor = 3600;
-		text = 'hrs';
+		text = 'hr';
 	} else if (blockSeconds >= 86400) {
 		divisor = 86400;
-		text = 'days';
+		text = 'day';
 	}
 
-	return `${Math.round(blockSeconds / divisor)} ${text}`;
+	const roundedValue = Math.round(blockSeconds / divisor);
+	return `${roundedValue} ${text}${roundedValue !== 1 ? 's' : ''}`;
 };
 
 const AboutTrackCard: FC<IAboutTrackCardProps> = (props) => {


### PR DESCRIPTION
Before ->
![image](https://github.com/polkassembly/polkassembly/assets/71382301/661cb83d-9490-423b-a1a2-2d1506d968a7)

After ->
![image](https://github.com/polkassembly/polkassembly/assets/71382301/db204fd6-7c4c-4395-b482-df8b6b6899fe)
