### PR TITLE
feat: :sparkles: Rotating refresh tokens

### DIFF
--- a/dayjs-init.ts
+++ b/dayjs-init.ts
@@ -13,6 +13,4 @@ dayjs.extend(isBetween);
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
-export {
-	dayjs
-};
+export { dayjs };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "bn.js": "^5.2.1",
     "chart.js": "^4.2.1",
     "classnames": "^2.3.2",
+    "cookie": "^0.6.0",
     "crypto-random-string": "^5.0.0",
     "dayjs": "^1.11.7",
     "detect-browser": "^5.3.0",

--- a/pages/api/v1/auth/actions/addressLogin.ts
+++ b/pages/api/v1/auth/actions/addressLogin.ts
@@ -8,6 +8,7 @@ import storeApiKeyUsage from '~src/api-middlewares/storeApiKeyUsage';
 import withErrorHandling from '~src/api-middlewares/withErrorHandling';
 import authServiceInstance from '~src/auth/auth';
 import { MessageType, IAuthResponse } from '~src/auth/types';
+import getRefreshTokenSerializedCookie from '~src/api-utils/getRefreshTokenSerializedCookie';
 
 async function handler(req: NextApiRequest, res: NextApiResponse<IAuthResponse | MessageType>) {
 	storeApiKeyUsage(req);
@@ -18,10 +19,15 @@ async function handler(req: NextApiRequest, res: NextApiResponse<IAuthResponse |
 
 	if (!address || !signature || !wallet) return res.status(400).json({ message: 'Missing parameters in request body' });
 
-	const { isTFAEnabled = false, tfa_token = '', token = '', user_id } = await authServiceInstance.AddressLogin(address, signature, wallet, multisig);
+	const { isTFAEnabled = false, tfa_token = '', token = '', user_id, refresh_token } = await authServiceInstance.AddressLogin(address, signature, wallet, multisig);
+
 	if (!token && !isTFAEnabled) return res.status(401).json({ message: 'Something went wrong. Please try again.' });
 
 	if (isTFAEnabled) return res.status(200).json({ isTFAEnabled, tfa_token, user_id });
+
+	if (!refresh_token) return res.status(500).json({ message: 'Cannot generate refresh-token. Please try again.' });
+
+	res.setHeader('Set-Cookie', getRefreshTokenSerializedCookie(refresh_token));
 
 	return res.status(200).json({ isTFAEnabled, token });
 }

--- a/pages/api/v1/auth/actions/login.ts
+++ b/pages/api/v1/auth/actions/login.ts
@@ -6,6 +6,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import storeApiKeyUsage from '~src/api-middlewares/storeApiKeyUsage';
 
 import withErrorHandling from '~src/api-middlewares/withErrorHandling';
+import getRefreshTokenSerializedCookie from '~src/api-utils/getRefreshTokenSerializedCookie';
 import authServiceInstance from '~src/auth/auth';
 import { MessageType, IAuthResponse } from '~src/auth/types';
 
@@ -17,10 +18,14 @@ async function handler(req: NextApiRequest, res: NextApiResponse<IAuthResponse |
 
 	if (!username || !password) return res.status(400).json({ message: 'Missing parameters in request body' });
 
-	const { isTFAEnabled = false, tfa_token = '', token = '', user_id } = await authServiceInstance.Login(username, password);
+	const { isTFAEnabled = false, tfa_token = '', token = '', user_id, refresh_token } = await authServiceInstance.Login(username, password);
 	if (!token && !isTFAEnabled) return res.status(401).json({ message: 'Invalid username or password' });
 
 	if (isTFAEnabled) return res.status(200).json({ isTFAEnabled, tfa_token, user_id });
+
+	if (!refresh_token) return res.status(500).json({ message: 'Cannot generate refresh-token. Please try again.' });
+
+	res.setHeader('Set-Cookie', getRefreshTokenSerializedCookie(refresh_token));
 
 	return res.status(200).json({ isTFAEnabled, token });
 }

--- a/pages/api/v1/auth/actions/refreshAccessToken.ts
+++ b/pages/api/v1/auth/actions/refreshAccessToken.ts
@@ -1,0 +1,59 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { NextApiRequest, NextApiResponse } from 'next';
+import storeApiKeyUsage from '~src/api-middlewares/storeApiKeyUsage';
+
+import withErrorHandling from '~src/api-middlewares/withErrorHandling';
+import authServiceInstance from '~src/auth/auth';
+import { MessageType, IAuthResponse, IRefreshTokenPayload } from '~src/auth/types';
+import getRefreshTokenSerializedCookie from '~src/api-utils/getRefreshTokenSerializedCookie';
+import getUserIdFromJWT from '~src/auth/utils/getUserIdFromJWT';
+import getUserFromUserId from '~src/auth/utils/getUserFromUserId';
+import { decode } from 'jsonwebtoken';
+
+async function handler(req: NextApiRequest, res: NextApiResponse<IAuthResponse | MessageType>) {
+	storeApiKeyUsage(req);
+
+	if (req.method !== 'POST') return res.status(405).json({ message: 'Invalid request method, POST required.' });
+
+	// read refresh_token from cookies
+	const refresh_token = req.cookies?.refresh_token || '';
+
+	if (!refresh_token) return res.status(400).json({ message: 'Invalid request.' });
+
+	// verify if refresh_token is valid
+	const refreshTokenPublicKey = process.env.REFRESH_TOKEN_PUBLIC_KEY?.replace(/\\n/gm, '\n');
+
+	const id = getUserIdFromJWT(refresh_token, refreshTokenPublicKey);
+
+	// not valid
+	if (!id) return res.status(401).json({ message: 'Invalid request. Please login again.' });
+
+	// if valid -> get new access token and a new refresh_token
+	const decodedRefreshToken = decode(refresh_token) as IRefreshTokenPayload;
+
+	const user = await getUserFromUserId(id);
+	const newAccessToken = await authServiceInstance.getSignedToken({
+		...user,
+		login_address: decodedRefreshToken.login_address,
+		login_wallet: decodedRefreshToken.login_wallet
+	});
+
+	const newRefreshToken = await authServiceInstance.getRefreshToken({
+		login_address: decodedRefreshToken.login_address,
+		login_wallet: decodedRefreshToken.login_wallet,
+		user_id: id
+	});
+
+	// send access token as response and send refresh token in cookie
+
+	if (!newAccessToken || !newRefreshToken) return res.status(401).json({ message: 'Something went wrong. Please try again.' });
+
+	res.setHeader('Set-Cookie', getRefreshTokenSerializedCookie(newRefreshToken));
+
+	return res.status(200).json({ token: newAccessToken });
+}
+
+export default withErrorHandling(handler);

--- a/src/api-utils/getRefreshTokenSerializedCookie.ts
+++ b/src/api-utils/getRefreshTokenSerializedCookie.ts
@@ -1,0 +1,10 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { serialize } from 'cookie';
+import { REFRESH_TOKEN_COOKIE_OPTIONS } from '~src/global/refreshToken';
+
+export default function getRefreshTokenSerializedCookie(refresh_token: string) {
+	return serialize('refresh_token', refresh_token, REFRESH_TOKEN_COOKIE_OPTIONS);
+}

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -28,6 +28,7 @@ import {
 	HashedPassword,
 	IAddressProxyForEntry,
 	IAuthResponse,
+	IRefreshTokenPayload,
 	IUserPreference,
 	JWTPayloadType,
 	NotificationSettings,
@@ -43,6 +44,7 @@ import nameBlacklist from './utils/nameBlacklist';
 import { verifyMetamaskSignature } from './utils/verifyMetamaskSignature';
 import verifyUserPassword from './utils/verifyUserPassword';
 import getSubstrateAddress from '~src/util/getSubstrateAddress';
+import { REFRESH_TOKEN_LIFE_IN_SECONDS } from '~src/global/refreshToken';
 
 process.env.JWT_PRIVATE_KEY = process.env.JWT_PRIVATE_KEY && process.env.JWT_PRIVATE_KEY.replace(/\\n/gm, '\n');
 process.env.JWT_PUBLIC_KEY = process.env.JWT_PUBLIC_KEY && process.env.JWT_PUBLIC_KEY.replace(/\\n/gm, '\n');
@@ -50,6 +52,9 @@ process.env.JWT_PUBLIC_KEY = process.env.JWT_PUBLIC_KEY && process.env.JWT_PUBLI
 const privateKey = process.env.NODE_ENV === 'test' ? process.env.JWT_PRIVATE_KEY_TEST : process.env.JWT_PRIVATE_KEY?.replace(/\\n/gm, '\n');
 const jwtPublicKey = process.env.NODE_ENV === 'test' ? process.env.JWT_PUBLIC_KEY_TEST : process.env.JWT_PUBLIC_KEY?.replace(/\\n/gm, '\n');
 const passphrase = process.env.NODE_ENV === 'test' ? process.env.JWT_KEY_PASSPHRASE_TEST : process.env.JWT_KEY_PASSPHRASE;
+
+const refreshTokenPrivateKey = process.env.REFRESH_TOKEN_PRIVATE_KEY?.replace(/\\n/gm, '\n');
+const refreshTokenPassphrase = process.env.REFRESH_TOKEN_PASSPHRASE;
 
 export const ONE_DAY = 24 * 60 * 60; // (expressed in seconds)
 export const FIVE_MIN = 5 * 60; // (expressed in seconds)
@@ -243,6 +248,7 @@ class AuthService {
 
 		return {
 			isTFAEnabled,
+			refresh_token: await this.getRefreshToken({ user_id: user.id }),
 			token: await this.getSignedToken(user)
 		};
 	}
@@ -353,6 +359,7 @@ class AuthService {
 
 		return {
 			isTFAEnabled,
+			refresh_token: await this.getRefreshToken({ login_address: address, login_wallet: wallet, user_id: user.id }),
 			token: await this.getSignedToken({
 				...user,
 				login_address: address,
@@ -998,7 +1005,26 @@ class AuthService {
 			};
 		}
 
-		return jwt.sign(tokenContent, { key: privateKey, passphrase }, { algorithm: 'RS256', expiresIn: '100d' });
+		return jwt.sign(tokenContent, { key: privateKey, passphrase }, { algorithm: 'RS256', expiresIn: '30s' });
+	}
+
+	public async getRefreshToken({ user_id, login_address, login_wallet }: { user_id: number; login_address?: string; login_wallet?: Wallet }): Promise<string> {
+		if (!refreshTokenPrivateKey) {
+			throw apiErrorWithStatusCode('REFRESH_TOKEN_PRIVATE_KEY not set. Aborting.', 403);
+		}
+
+		if (!refreshTokenPassphrase) {
+			throw apiErrorWithStatusCode('REFRESH_TOKEN_PASSPHRASE not set. Aborting.', 403);
+		}
+
+		const tokenContent: IRefreshTokenPayload = {
+			iat: Math.floor(Date.now() / 1000),
+			id: user_id,
+			login_address,
+			login_wallet
+		};
+
+		return jwt.sign(tokenContent, { key: refreshTokenPrivateKey, passphrase: refreshTokenPassphrase }, { algorithm: 'RS256', expiresIn: `${REFRESH_TOKEN_LIFE_IN_SECONDS}s` });
 	}
 
 	public async CreatePostStart(address: string): Promise<string> {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1005,7 +1005,8 @@ class AuthService {
 			};
 		}
 
-		return jwt.sign(tokenContent, { key: privateKey, passphrase }, { algorithm: 'RS256', expiresIn: '30s' });
+		// TODO: change to 1 hour for prod
+		return jwt.sign(tokenContent, { key: privateKey, passphrase }, { algorithm: 'RS256', expiresIn: '60s' });
 	}
 
 	public async getRefreshToken({ user_id, login_address, login_wallet }: { user_id: number; login_address?: string; login_wallet?: Wallet }): Promise<string> {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1005,8 +1005,8 @@ class AuthService {
 			};
 		}
 
-		// TODO: change to 1 hour for prod
-		return jwt.sign(tokenContent, { key: privateKey, passphrase }, { algorithm: 'RS256', expiresIn: '60s' });
+		// valid for 1 day
+		return jwt.sign(tokenContent, { key: privateKey, passphrase }, { algorithm: 'RS256', expiresIn: '86400s' });
 	}
 
 	public async getRefreshToken({ user_id, login_address, login_wallet }: { user_id: number; login_address?: string; login_wallet?: Wallet }): Promise<string> {

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -179,11 +179,20 @@ export interface JWTPayloadType {
 	exp?: number;
 }
 
+export interface IRefreshTokenPayload {
+	iat: number;
+	id: number;
+	exp?: number;
+	login_address?: string;
+	login_wallet?: Wallet;
+}
+
 export interface IAuthResponse {
 	token?: string;
 	user_id?: number;
 	isTFAEnabled?: boolean;
 	tfa_token?: string;
+	refresh_token?: string;
 }
 
 export interface AuthObjectType extends TokenType {

--- a/src/auth/utils/getUserIdFromJWT.ts
+++ b/src/auth/utils/getUserIdFromJWT.ts
@@ -25,9 +25,9 @@ export default function getUserIdFromJWT(token: string, publicKey: string | unde
 		throw apiErrorWithStatusCode(messages.INVALID_JWT, 403);
 	}
 
-	if (!decoded.sub) {
+	if (!String(decoded.id)) {
 		throw apiErrorWithStatusCode(messages.INVALID_USER_ID_IN_JWT, 403);
 	}
 
-	return Number(decoded.sub);
+	return Number(decoded.id);
 }

--- a/src/global/refreshToken.ts
+++ b/src/global/refreshToken.ts
@@ -1,0 +1,17 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { CookieSerializeOptions } from 'cookie';
+
+const REFRESH_TOKEN_LIFE_IN_SECONDS = 60 * 60 * 24 * 7; // One week
+
+const REFRESH_TOKEN_COOKIE_OPTIONS: CookieSerializeOptions = {
+	httpOnly: false,
+	maxAge: REFRESH_TOKEN_LIFE_IN_SECONDS,
+	path: '/',
+	sameSite: true,
+	secure: process.env.NEXT_PUBLIC_APP_ENV === 'production'
+};
+
+export { REFRESH_TOKEN_COOKIE_OPTIONS, REFRESH_TOKEN_LIFE_IN_SECONDS };

--- a/src/global/refreshToken.ts
+++ b/src/global/refreshToken.ts
@@ -4,7 +4,7 @@
 
 import { CookieSerializeOptions } from 'cookie';
 
-const REFRESH_TOKEN_LIFE_IN_SECONDS = 60 * 60 * 24 * 7 * 3; // 3 weeks
+const REFRESH_TOKEN_LIFE_IN_SECONDS = 60 * 60 * 24 * 7 * 4; // 4 weeks
 
 const REFRESH_TOKEN_COOKIE_OPTIONS: CookieSerializeOptions = {
 	httpOnly: false,

--- a/src/global/refreshToken.ts
+++ b/src/global/refreshToken.ts
@@ -4,7 +4,7 @@
 
 import { CookieSerializeOptions } from 'cookie';
 
-const REFRESH_TOKEN_LIFE_IN_SECONDS = 60 * 60 * 24 * 7; // One week
+const REFRESH_TOKEN_LIFE_IN_SECONDS = 60 * 60 * 24 * 7 * 3; // 3 weeks
 
 const REFRESH_TOKEN_COOKIE_OPTIONS: CookieSerializeOptions = {
 	httpOnly: false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -146,3 +146,5 @@ export type TAppState = ReturnType<TAppStore['getState']>;
 export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, TAppState, unknown, Action>;
 
 export const wrapper = createWrapper<TAppStore>(makeStore);
+
+export const store = makeStore();

--- a/src/redux/userDetails/index.ts
+++ b/src/redux/userDetails/index.ts
@@ -6,6 +6,7 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { HYDRATE } from 'next-redux-wrapper';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import { deleteLocalStorageToken } from '~src/services/auth.service';
+import deleteCookie from '~src/util/deleteCookie';
 
 const initialState: IUserDetailsStore = {
 	addresses: [],
@@ -44,6 +45,7 @@ export const userDetailsStore = createSlice({
 	name: 'userDetails',
 	reducers: {
 		setLogout: (state) => {
+			deleteCookie('refresh_token');
 			deleteLocalStorageToken();
 			localStorage.removeItem('delegationWallet');
 			localStorage.removeItem('loginWallet');

--- a/src/util/deleteCookie.ts
+++ b/src/util/deleteCookie.ts
@@ -1,0 +1,7 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+export default function deleteCookie(name: string) {
+	document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+}

--- a/src/util/getCookieValueByName.ts
+++ b/src/util/getCookieValueByName.ts
@@ -1,0 +1,9 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+export default function getCookieValueByName(name: string) {
+	if (!window || !document?.cookie) return '';
+
+	return document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)')?.pop() || '';
+}

--- a/src/util/nextApiClientFetch.ts
+++ b/src/util/nextApiClientFetch.ts
@@ -6,17 +6,19 @@ import { getLocalStorageToken } from '~src/services/auth.service';
 import getNetwork from './getNetwork';
 
 import messages from './messages';
+import reAuthClient from './reAuthClient';
 
 async function nextApiClientFetch<T>(url: string, data?: { [key: string]: any }, method?: 'GET' | 'POST'): Promise<{ data?: T; error?: string }> {
 	const network = getNetwork();
 
 	const currentURL = new URL(window.location.href);
-	const token = currentURL.searchParams.get('token') || getLocalStorageToken();
+	const token = currentURL.searchParams.get('token') || (await reAuthClient()) || getLocalStorageToken();
 
 	const response = await fetch(`${window.location.origin}/${url}`, {
 		body: JSON.stringify(data),
+		credentials: 'include',
 		headers: {
-			Authorization: 'Bearer ' + token,
+			Authorization: `Bearer ${token}`,
 			'Content-Type': 'application/json',
 			'x-api-key': process.env.NEXT_PUBLIC_POLKASSEMBLY_API_KEY || '',
 			'x-network': network
@@ -26,10 +28,11 @@ async function nextApiClientFetch<T>(url: string, data?: { [key: string]: any },
 
 	const resJSON = await response.json();
 
-	if (response.status === 200)
+	if (response.status === 200) {
 		return {
 			data: resJSON as T
 		};
+	}
 
 	return {
 		error: resJSON.message || messages.API_FETCH_ERROR

--- a/src/util/reAuthClient.ts
+++ b/src/util/reAuthClient.ts
@@ -1,0 +1,49 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { dayjs } from 'dayjs-init';
+import { decodeToken } from 'react-jwt';
+import { IAuthResponse, IRefreshTokenPayload, JWTPayloadType } from '~src/auth/types';
+import { getLocalStorageToken, storeLocalStorageToken } from '~src/services/auth.service';
+import getCookieValueByName from './getCookieValueByName';
+import getNetwork from './getNetwork';
+
+export default async function reAuthClient() {
+	try {
+		//check if current access token is valid
+		const access_token = getLocalStorageToken() || '';
+		const { exp = null } = decodeToken<JWTPayloadType>(access_token) || {};
+
+		// if access token is valid: early return, no need to re-auth
+		if (access_token && exp && dayjs().isBefore(dayjs.unix(exp))) return access_token;
+
+		// access token is invalid, now if valid refresh_token is available, try to re-auth
+		const refresh_token = getCookieValueByName('refresh_token');
+		const { exp: refreshTokenExp = null } = decodeToken<IRefreshTokenPayload>(refresh_token) || {};
+
+		// if valid refresh_token
+		if (refresh_token && refreshTokenExp && dayjs().isBefore(dayjs.unix(refreshTokenExp))) {
+			// try to re-auth
+			const newAccessTokenRes = await fetch(`${window.location.origin}/api/v1/auth/actions/refreshAccessToken`, {
+				credentials: 'include',
+				headers: {
+					'Content-Type': 'application/json',
+					'x-api-key': process.env.NEXT_PUBLIC_POLKASSEMBLY_API_KEY || '',
+					'x-network': getNetwork()
+				},
+				method: 'POST'
+			});
+
+			const { token } = ((await newAccessTokenRes.json()) || {}) as IAuthResponse;
+
+			if (token) {
+				//TODO: also replace redux details
+				storeLocalStorageToken(token);
+				return token;
+			}
+		}
+	} catch (e) {
+		console.log('Error in re-authenticating, please try again :', e);
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4505,6 +4505,11 @@ convert-source-map@^1.7.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
+cookie@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
+  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+
 cookiejar@^2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"


### PR DESCRIPTION
### Implements rotating refresh token.

1. Upon logging in, the user will start to receive a `refresh_token` in his cookies along with an `access_token` in the response.
2. When user is making request to BE using nextApiClientFetch - we check if `access_token`  is expired.
3. If it is expired, we check if we have a valid refresh_token in the cookies.
4. Using that refresh_token, we fetch a new access_token.
5. After the refresh_token is used, it will be replaced by a new refresh_token.

`refresh_token` is long-lived ~ 3 weeks
`access_token` is short-lived ~ 1 day

`NOTE: for development and testing purposes these values have been set to a very short interval. They will be tweaked to the above-mentioned values for production.`

UPDATE: Prod values for tokens pushed.