### PR TITLE
Fix: re fetch summary

### DIFF
--- a/pages/api/v1/auth/actions/editPostComment.ts
+++ b/pages/api/v1/auth/actions/editPostComment.ts
@@ -75,6 +75,7 @@ const handler: NextApiHandler<MessageType> = async (req, res) => {
 		await commentRef.update({
 			content,
 			history,
+			isDeleted: false,
 			sentiment,
 			updated_at: last_comment_at
 		});


### PR DESCRIPTION
Re fetching summary if the user is deleted his comment and edit the same comment 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced comment editing process with the introduction of an `isDeleted` property for better comment state management.
  
- **Bug Fixes**
	- Improved error handling with more descriptive logging for comment saving errors.
  
- **Chores**
	- Encapsulated post data retrieval logic in a try-catch block to enhance stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->