### PR TITLE
added polymesh testnet's subsquid url

### DIFF
--- a/src/global/networkConstants.ts
+++ b/src/global/networkConstants.ts
@@ -1549,7 +1549,7 @@ export const chainProperties: types.ChainPropType = {
 		ss58Format: 42,
 		tokenDecimals: 6,
 		tokenSymbol: tokenSymbol.POLYX,
-		subsquidUrl: '',
+		subsquidUrl: 'https://polkassembly.squids.live/polymesh-test-polkassembly/v/v1/graphql',
 		treasuryProposalBondPercent: null,
 		treasuryProposalMinBond: null,
 		treasuryProposalMaxBond: null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
	- Updated Polymesh Test network configuration with a new Subsquid GraphQL endpoint URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->