### PR TITLE
Fix: Optional parent proxy title display in Address component

### DIFF
--- a/src/components/Post/GovernanceSideBar/Modal/VoteData/VoterRow.tsx
+++ b/src/components/Post/GovernanceSideBar/Modal/VoteData/VoterRow.tsx
@@ -175,6 +175,7 @@ const VoterRow: FC<IVoterRow> = ({
 									isSubVisible={false}
 									displayInline
 									showFullAddress
+									showTitle={false}
 									address={voteData?.voter}
 								/>
 							</a>
@@ -188,6 +189,7 @@ const VoterRow: FC<IVoterRow> = ({
 									isSubVisible={false}
 									displayInline
 									showFullAddress
+									showTitle={false}
 									address={voteData?.voter}
 								/>
 							</div>

--- a/src/components/Post/GovernanceSideBar/Modal/VoteData/VoterRow.tsx
+++ b/src/components/Post/GovernanceSideBar/Modal/VoteData/VoterRow.tsx
@@ -175,7 +175,7 @@ const VoterRow: FC<IVoterRow> = ({
 									isSubVisible={false}
 									displayInline
 									showFullAddress
-									showTitle={false}
+									showProxyTitle={false}
 									address={voteData?.voter}
 								/>
 							</a>
@@ -189,7 +189,7 @@ const VoterRow: FC<IVoterRow> = ({
 									isSubVisible={false}
 									displayInline
 									showFullAddress
-									showTitle={false}
+									showProxyTitle={false}
 									address={voteData?.voter}
 								/>
 							</div>

--- a/src/ui-components/Address.tsx
+++ b/src/ui-components/Address.tsx
@@ -82,6 +82,7 @@ interface Props {
 	isUsedInAccountsPage?: boolean;
 	disableParentProxyAddressTitle?: boolean;
 	showCopyIcon?: boolean;
+	showTitle?: boolean;
 }
 
 const shortenUsername = (username: string, usernameMaxLength?: number) => {
@@ -164,6 +165,7 @@ const Address = (props: Props) => {
 		addressClassName,
 		disableAddressClick = false,
 		disableHeader,
+		showTitle = true,
 		isTruncateUsername = true,
 		usernameClassName,
 		extensionName,
@@ -664,7 +666,7 @@ const Address = (props: Props) => {
 				</div>
 			</Tooltip>
 			{/* proxy parent title */}
-			{!!identity?.parentProxyTitle && (displayInline || isProfileView || disableHeader) && (
+			{!!identity?.parentProxyTitle && (displayInline || isProfileView || disableHeader) && showTitle && (
 				<ParentProxyTitle
 					disableParentProxyAddressTitle={disableParentProxyAddressTitle}
 					title={identity?.parentProxyTitle}

--- a/src/ui-components/Address.tsx
+++ b/src/ui-components/Address.tsx
@@ -82,7 +82,7 @@ interface Props {
 	isUsedInAccountsPage?: boolean;
 	disableParentProxyAddressTitle?: boolean;
 	showCopyIcon?: boolean;
-	showTitle?: boolean;
+	showProxyTitle?: boolean;
 }
 
 const shortenUsername = (username: string, usernameMaxLength?: number) => {
@@ -165,13 +165,14 @@ const Address = (props: Props) => {
 		addressClassName,
 		disableAddressClick = false,
 		disableHeader,
-		showTitle = true,
+		showProxyTitle = true,
 		isTruncateUsername = true,
 		usernameClassName,
 		extensionName,
 		usernameMaxLength,
 		addressMaxLength,
 		addressOtherTextType,
+
 		passedUsername,
 		ethIdenticonSize,
 		isVoterAddress,
@@ -666,7 +667,7 @@ const Address = (props: Props) => {
 				</div>
 			</Tooltip>
 			{/* proxy parent title */}
-			{!!identity?.parentProxyTitle && (displayInline || isProfileView || disableHeader) && showTitle && (
+			{!!identity?.parentProxyTitle && (displayInline || isProfileView || disableHeader) && showProxyTitle && (
 				<ParentProxyTitle
 					disableParentProxyAddressTitle={disableParentProxyAddressTitle}
 					title={identity?.parentProxyTitle}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced address display in governance views for a cleaner, streamlined user experience. Addresses now conditionally hide title information where applicable, while still preserving the option to display titles when needed through the new `showProxyTitle` property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->