### PR TITLE
remove blank staus on discussions

### DIFF
--- a/src/components/Gov2Home/Gov2LatestActivity/AllGov2PostsTable.tsx
+++ b/src/components/Gov2Home/Gov2LatestActivity/AllGov2PostsTable.tsx
@@ -99,7 +99,7 @@ const getCols = (theme?: string): ColumnsType<IPostsRowData> => {
 				if (status || obj.spam_users_count)
 					return (
 						<div className='flex items-center gap-x-2'>
-							{status && status !== '-' ? (
+							{status ? (
 								<StatusTag
 									theme={theme}
 									status={status}
@@ -166,7 +166,7 @@ const AllGov2PostsTable: FC<IAllGov2PostsTableProps> = ({ posts, error }) => {
 					username: post?.username,
 					created_at: post.created_at,
 					origin: post.origin || post.type || null,
-					status: post.status || '-',
+					status: post.status || '',
 					sub_title: subTitle,
 					track: Number(post.track_number),
 					type: post.type,

--- a/src/components/Gov2Home/Gov2LatestActivity/AllGov2PostsTable.tsx
+++ b/src/components/Gov2Home/Gov2LatestActivity/AllGov2PostsTable.tsx
@@ -99,7 +99,7 @@ const getCols = (theme?: string): ColumnsType<IPostsRowData> => {
 				if (status || obj.spam_users_count)
 					return (
 						<div className='flex items-center gap-x-2'>
-							{status ? (
+							{status && status !== '-' ? (
 								<StatusTag
 									theme={theme}
 									status={status}

--- a/src/components/Home/LatestActivity/PostsTable.tsx
+++ b/src/components/Home/LatestActivity/PostsTable.tsx
@@ -73,7 +73,7 @@ const PostsTable: FC<IPostsTableProps> = ({ posts, error, columns, type, count }
 			proposalHashBlock: post?.proposalHashBlock || null,
 			proposer: proposer,
 			spam_users_count: spam_users_count,
-			status: status || '-',
+			status: status || '',
 			tip_id: count - index - 1,
 			title,
 			topic: post?.topic?.name,

--- a/src/components/Home/LatestActivity/columns.tsx
+++ b/src/components/Home/LatestActivity/columns.tsx
@@ -90,7 +90,7 @@ const Status: any = {
 		if (status || obj.spam_users_count)
 			return (
 				<div className='flex items-center gap-x-2'>
-					{status ? <StatusTag status={status} /> : null}
+					{status && status !== '-' ? <StatusTag status={status} /> : null}
 					{obj.spam_users_count ? (
 						<div className='flex items-center justify-center'>
 							<Tooltip


### PR DESCRIPTION
Before
![Screenshot 2025-02-06 102221](https://github.com/user-attachments/assets/20936b9d-32aa-4eeb-b038-a423ccd7330a)

After
![Screenshot 2025-02-06 102202](https://github.com/user-attachments/assets/e92c74ed-347b-4299-a695-80d58b440755)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the status indicator display in activity tables to ensure that values explicitly set to "-" no longer show an unnecessary tag.
	- Updated the default value for status in activity tables from a hyphen to an empty string, enhancing the clarity of the status display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->