### PR TITLE
remove ROUND_UP from estimated time calculation

### DIFF
--- a/src/components/Post/GovernanceSideBar/index.tsx
+++ b/src/components/Post/GovernanceSideBar/index.tsx
@@ -577,9 +577,9 @@ const GovernanceSideBar: FC<IGovernanceSidebarProps> = (props) => {
 								const currentApproval = currentApprovalData[currentApprovalData.length - 1];
 								const currentSupport = currentSupportData[currentSupportData.length - 1];
 								progress = {
-									approval: approval ? approval.toFormat(2, BigNumber.ROUND_UP) : (currentApproval?.y?.toFixed(1) as any),
+									approval: approval ? approval.toFormat(2) : (currentApproval?.y?.toFixed(1) as any),
 									approvalThreshold: (approvalData.find((data) => data && data?.x >= currentApproval?.x)?.y as any) || 0,
-									support: support ? support.toFormat(2, BigNumber.ROUND_UP) : (currentSupport?.y?.toFixed(1) as any),
+									support: support ? support.toFormat(2) : (currentSupport?.y?.toFixed(1) as any),
 									supportThreshold: (supportData.find((data) => data && data?.x >= currentSupport?.x)?.y as any) || 0
 								};
 								setProgress(progress);
@@ -590,9 +590,9 @@ const GovernanceSideBar: FC<IGovernanceSidebarProps> = (props) => {
 					}
 				} else {
 					progress = {
-						approval: Number(approval?.toFormat(2, BigNumber.ROUND_UP) || 0),
+						approval: Number(approval?.toFormat(2) || 0),
 						approvalThreshold: 100,
-						support: Number(support?.toFormat(2, BigNumber.ROUND_UP) || 0),
+						support: Number(support?.toFormat(2) || 0),
 						supportThreshold: 50
 					};
 					setProgress(progress);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the display logic for progress indicators in the Governance sidebar, ensuring approval and support values now consistently show two decimal places without rounding upward.
  - Improved formatting when default values are applied, providing a more precise presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->