### PR TITLE
Fix/w3f delegates update

### DIFF
--- a/pages/api/v1/delegations/getAllDelegates.ts
+++ b/pages/api/v1/delegations/getAllDelegates.ts
@@ -191,7 +191,7 @@ export const getDelegatesData = async (network: string, address?: string | null)
 				address: getEncodedAddress(item.address, network),
 				bio: item?.shortDescription || '',
 				dataSource: ['w3f'],
-				image: '',
+				image: item?.image || '',
 				username: item?.username || ''
 			})) || []),
 			...(parityDelegates?.map((item: any) => ({

--- a/pages/api/v1/delegations/w3f-delegates-kusama.json
+++ b/pages/api/v1/delegations/w3f-delegates-kusama.json
@@ -58,6 +58,6 @@
 	"image": "https://i.ibb.co/7NYxpxWs/mdx-Editor-khushy1234-k-1745921355318.jpg",
 	"longDescription": "",
 	"name": "PERMANENCE DAO",
-	"shortDescription": ""
+	"shortDescription": "A global multi-disciplinary collective of incorporated and individual contributors committed to the growth of Kusama."
 }
 ]

--- a/pages/api/v1/delegations/w3f-delegates-kusama.json
+++ b/pages/api/v1/delegations/w3f-delegates-kusama.json
@@ -57,7 +57,14 @@
 	"address": "EicAs5s99x17qZcQzJMiBCfada9rGyEC6njfiBX3j2EPr9W",
 	"image": "https://i.ibb.co/7NYxpxWs/mdx-Editor-khushy1234-k-1745921355318.jpg",
 	"longDescription": "",
-	"name": "PERMANENCE DAO",
+	"name": "PERMANENCE DAO/HQ",
+	"shortDescription": "A global multi-disciplinary collective of incorporated and individual contributors committed to the growth of Kusama."
+},
+{
+	"address": "ELCdsyWFNC7twEeBcQvdpCmpJhGBgiVeWtaKqRqXGn5ATiA",
+	"image": "https://i.ibb.co/7NYxpxWs/mdx-Editor-khushy1234-k-1745921355318.jpg",
+	"longDescription": "",
+	"name": "PERMANENCE DAO/DV",
 	"shortDescription": "A global multi-disciplinary collective of incorporated and individual contributors committed to the growth of Kusama."
 }
 ]

--- a/pages/api/v1/delegations/w3f-delegates-kusama.json
+++ b/pages/api/v1/delegations/w3f-delegates-kusama.json
@@ -52,5 +52,12 @@
 		"longDescription": "",
 		"name": "Polkadot Hungary DAO",
 		"shortDescription": ""
+},
+{
+	"address": "EicAs5s99x17qZcQzJMiBCfada9rGyEC6njfiBX3j2EPr9W",
+	"image": "https://i.ibb.co/7NYxpxWs/mdx-Editor-khushy1234-k-1745921355318.jpg",
+	"longDescription": "",
+	"name": "PERMANENCE DAO",
+	"shortDescription": ""
 }
 ]

--- a/pages/api/v1/delegations/w3f-delegates-polkadot.json
+++ b/pages/api/v1/delegations/w3f-delegates-polkadot.json
@@ -110,7 +110,14 @@
 		"address": "15ubZj6T7NUYyQw6j4XBkEMJ2vew5w9kqKEcN1QG7Z1weKDV",
 		"image": "https://i.ibb.co/7NYxpxWs/mdx-Editor-khushy1234-k-1745921355318.jpg",
 		"longDescription": "",
-		"name": "PERMANENCE DAO",
+		"name": "PERMANENCE DAO/HQ",
 		"shortDescription": "A global multi-disciplinary collective of incorporated and individual contributors committed to the growth of Polkadot."
-  }
+  },
+  {
+	"address": "14ZaBmSkr6JWf4fUDHbApqHBvbeeAEBSAARxgzXHcSruLELJ",
+	"image": "https://i.ibb.co/7NYxpxWs/mdx-Editor-khushy1234-k-1745921355318.jpg",
+	"longDescription": "",
+	"name": "PERMANENCE DAO/DV",
+	"shortDescription": "A global multi-disciplinary collective of incorporated and individual contributors committed to the growth of Polkadot."
+}
 ]

--- a/pages/api/v1/delegations/w3f-delegates-polkadot.json
+++ b/pages/api/v1/delegations/w3f-delegates-polkadot.json
@@ -106,5 +106,11 @@
 		"longDescription": "",
 		"name": "Polkadot Hungary DAO",
 		"shortDescription": ""
+  },{
+		"address": "15ubZj6T7NUYyQw6j4XBkEMJ2vew5w9kqKEcN1QG7Z1weKDV",
+		"image": "https://i.ibb.co/7NYxpxWs/mdx-Editor-khushy1234-k-1745921355318.jpg",
+		"longDescription": "",
+		"name": "PERMANENCE DAO",
+		"shortDescription": "A global multi-disciplinary collective of incorporated and individual contributors committed to the growth of Polkadot."
   }
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added two new delegates, "PERMANENCE DAO/HQ" and "PERMANENCE DAO/DV," to the W3F delegates list for both Kusama and Polkadot, including profile images and descriptions.
- **Bug Fixes**
  - Improved display of delegate images by showing delegate images when available instead of always showing a blank image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->