### PR TITLE
Enhance network detection by adding support for polkadot-old in getNe…

### DIFF
--- a/src/api-utils/index.ts
+++ b/src/api-utils/index.ts
@@ -117,6 +117,8 @@ export function getNetworkFromReqHeaders(headers: IncomingHttpHeaders) {
 			network = 'polkadot';
 		} else if (network == 'moonriver-test') {
 			network = 'moonriver';
+		} else if (network == 'polkadot-old') {
+			network = 'polkadot';
 		} else {
 			network = process.env.NEXT_PUBLIC_APP_ENV === 'development' ? defaultNetwork : network;
 		}

--- a/src/global/defaultNetwork.ts
+++ b/src/global/defaultNetwork.ts
@@ -3,6 +3,14 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 export const defaultNetwork = (() => {
+	// Check if we're in a browser environment and the subdomain is polkadot-old
+	if (typeof window !== 'undefined') {
+		const hostname = window.location.hostname;
+		if (hostname.startsWith('polkadot-old.')) {
+			return 'polkadot';
+		}
+	}
+
 	const defaultNetwork = process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
 	if (!defaultNetwork) {
 		throw Error('Please set "NEXT_PUBLIC_DEFAULT_NETWORK" environment variable');

--- a/src/util/getNetwork.ts
+++ b/src/util/getNetwork.ts
@@ -41,6 +41,8 @@ export default function getNetwork(): Network {
 		network = 'moonriver';
 	} else if (network == 'moonbase-test') {
 		network = 'moonbase';
+	} else if (network == 'polkadot-old') {
+		network = 'polkadot';
 	}
 
 	if (!possibleNetworks.includes(network)) {


### PR DESCRIPTION
…tworkFromReqHeaders and defaultNetwork, ensuring proper handling of legacy subdomain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the "polkadot-old" network, ensuring it is now consistently recognized and treated as "polkadot" throughout the application.
- **Chores**
	- Enhanced compatibility for legacy network subdomains in browser environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->