### PR TITLE
Add user creation API endpoint and update user handling in Firestore …

### DIFF
--- a/cloud-functions/src/index.ts
+++ b/cloud-functions/src/index.ts
@@ -143,7 +143,7 @@ exports.onUserWritten = functions
 			});
 
 		// update user in v2firebase
-		const url = 'https://api.polkassembly.io/api/v2/webhook/user_created';
+		const url = 'https://polkadot.polkassembly.io/api/v2/webhook/user_created';
 
 		const user: IUser = {
 			id: Number(userId),

--- a/pages/api/v1/users/createUser.ts
+++ b/pages/api/v1/users/createUser.ts
@@ -1,0 +1,33 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import type { NextApiHandler } from 'next';
+import withErrorHandling from '~src/api-middlewares/withErrorHandling';
+import { isValidNetwork } from '~src/api-utils';
+import { MessageType } from '~src/auth/types';
+import storeApiKeyUsage from '~src/api-middlewares/storeApiKeyUsage';
+import authServiceInstance from '~src/auth/auth';
+
+interface Props {
+	email: string;
+	password: string;
+	username: string;
+	web3signup: boolean;
+	custom_username: boolean;
+}
+
+const handler: NextApiHandler<any | MessageType> = async (req, res) => {
+	storeApiKeyUsage(req);
+	const network = String(req.headers['x-network']);
+	if (!network || !isValidNetwork(network)) return res.status(400).json({ message: 'Invalid network in request header' });
+
+	const { email, password, username, web3signup, custom_username } = req.body as Props;
+
+	if (!email || !password || !username || !custom_username) return res.status(400).json({ message: 'Invalid params' });
+
+	await authServiceInstance.createUser(email, password, username, web3signup, network, custom_username);
+
+	return res.status(200).json({ message: 'User created successfully' });
+};
+export default withErrorHandling(handler);

--- a/pages/api/v1/users/createUser.ts
+++ b/pages/api/v1/users/createUser.ts
@@ -15,18 +15,22 @@ interface Props {
 	username: string;
 	web3signup: boolean;
 	custom_username: boolean;
+	salt: string;
 }
 
 const handler: NextApiHandler<any | MessageType> = async (req, res) => {
 	storeApiKeyUsage(req);
 	const network = String(req.headers['x-network']);
+	const toolsPassphrase = String(req.headers['x-tools-passphrase']);
+
+	if (toolsPassphrase !== process.env.TOOLS_PASSPHRASE) return res.status(401).json({ message: 'Unauthorized' });
 	if (!network || !isValidNetwork(network)) return res.status(400).json({ message: 'Invalid network in request header' });
 
-	const { email, password, username, web3signup, custom_username } = req.body as Props;
+	const { email, password, username, web3signup, custom_username, salt } = req.body as Props;
 
-	if (!email || !password || !username || !custom_username) return res.status(400).json({ message: 'Invalid params' });
+	if (!email || !password || !username || !salt) return res.status(400).json({ message: 'Invalid params' });
 
-	await authServiceInstance.createUser(email, password, username, web3signup, network, custom_username);
+	await authServiceInstance.createUser(email, password, username, web3signup, network, custom_username, salt);
 
 	return res.status(200).json({ message: 'User created successfully' });
 };

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -108,7 +108,7 @@ class AuthService {
 		}
 	}
 
-	private async createUser(email: string, newPassword: string, username: string, web3signup: boolean, network: string, custom_username: boolean = false): Promise<User> {
+	async createUser(email: string, newPassword: string, username: string, web3signup: boolean, network: string, custom_username: boolean = false): Promise<User> {
 		const { password, salt } = await this.getSaltAndHashedPassword(newPassword);
 
 		const newUserId = (await this.getLatestUserCount()) + 1;

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -108,8 +108,8 @@ class AuthService {
 		}
 	}
 
-	async createUser(email: string, newPassword: string, username: string, web3signup: boolean, network: string, custom_username: boolean = false): Promise<User> {
-		const { password, salt } = await this.getSaltAndHashedPassword(newPassword);
+	async createUser(email: string, newPassword: string, username: string, web3signup: boolean, network: string, custom_username: boolean = false, salt?: string): Promise<User> {
+		const { password, salt: hashedSalt } = await this.getSaltAndHashedPassword(newPassword);
 
 		const newUserId = (await this.getLatestUserCount()) + 1;
 
@@ -123,7 +123,7 @@ class AuthService {
 			password: password,
 			profile: PROFILE_DETAILS_DEFAULTS,
 			profile_score: 0,
-			salt: salt,
+			salt: salt || hashedSalt,
 			username: username,
 			web3_signup: web3signup
 		};


### PR DESCRIPTION
…functions

- Introduced a new API endpoint for user creation in , validating input parameters and utilizing the  for user registration.
- Updated Firestore function in  to include user data structure and send a POST request to an external API upon user creation.
- Changed the  method in  to be public for accessibility from the new API endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint for user creation, allowing users to register via a POST request.
  - User creation now triggers a webhook notification to an external service upon successful registration.

- **Improvements**
  - Enhanced user data handling and validation during the registration process.
  - Added support for custom salt values during user registration to improve security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->