### PR TITLE
Refactor network handling to support v2 networks

### DIFF
--- a/pages/bounties-listing/index.tsx
+++ b/pages/bounties-listing/index.tsx
@@ -21,6 +21,7 @@ import { BOUNTIES_LISTING_LIMIT } from '~src/global/listingLimit';
 import { Pagination } from '~src/ui-components/Pagination';
 import BountiesTabItems from '~src/components/Bounties/BountiesListing/BountiesTabItems';
 import CuratorDashboardButton from '~src/components/CuratorDashboard/CuratorDashboardButton';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 interface IBountiesListingProps {
 	data?: {
@@ -104,10 +105,12 @@ const BountiesListing: FC<IBountiesListingProps> = (props) => {
 					<span className={`${spaceGrotesk.className} ${spaceGrotesk.variable} text-[32px] font-bold text-blue-light-high dark:text-blue-dark-high dark:text-lightWhite`}>
 						On-chain Bounties
 					</span>
-					<div className='flex gap-2'>
-						<BountyProposalActionButton className='hidden md:block' />
-						<CuratorDashboardButton />
-					</div>
+					{!v2SupportedNetworks.includes(network) && (
+						<div className='flex gap-2'>
+							<BountyProposalActionButton className='hidden md:block' />
+							<CuratorDashboardButton />
+						</div>
+					)}
 				</div>
 
 				<BountiesTabItems bounties={bounties} />

--- a/pages/discussions/index.tsx
+++ b/pages/discussions/index.tsx
@@ -25,7 +25,7 @@ import { useTheme } from 'next-themes';
 import OffChainTabs from '~src/components/Listing/OffChain/OffChainTabs';
 import OffChainPostsContainer from '~src/components/Listing/OffChain/OffChainPostsContainer';
 import { isForumSupportedNetwork } from '~src/global/ForumNetworks';
-
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 interface IDiscussionsProps {
 	data?: IPostsListingResponse;
 	error?: string;
@@ -120,12 +120,14 @@ const Discussions: FC<IDiscussionsProps> = (props) => {
 					<DiscussionsIcon className='text-lg text-lightBlue dark:text-icon-dark-inactive xs:mr-3 sm:mr-2 sm:mt-[2px]' />
 					Discussions({count})
 				</div>
-				<button
-					onClick={handleClick}
-					className='hidden cursor-pointer items-center justify-center whitespace-pre rounded-[4px] border-none bg-pink_primary  p-3 font-medium leading-[20px] tracking-[0.01em] text-white shadow-[0px_6px_18px_rgba(0,0,0,0.06)] outline-none xs:mt-3 sm:-mt-1 sm:flex sm:h-[40px] sm:w-[120px]'
-				>
-					+ Add Post
-				</button>
+				{!v2SupportedNetworks.includes(network) && (
+					<button
+						onClick={handleClick}
+						className='hidden cursor-pointer items-center justify-center whitespace-pre rounded-[4px] border-none bg-pink_primary  p-3 font-medium leading-[20px] tracking-[0.01em] text-white shadow-[0px_6px_18px_rgba(0,0,0,0.06)] outline-none xs:mt-3 sm:-mt-1 sm:flex sm:h-[40px] sm:w-[120px]'
+					>
+						+ Add Post
+					</button>
+				)}
 			</div>
 
 			{/* Intro and Create Post Button */}
@@ -135,12 +137,14 @@ const Discussions: FC<IDiscussionsProps> = (props) => {
 				</p>
 			</div>
 			<div className={'fixed bottom-0 z-50 -ml-3 w-full bg-white px-3 py-5 dark:bg-section-dark-overlay sm:hidden'}>
-				<button
-					onClick={handleClick}
-					className='flex h-10 w-full cursor-pointer items-center justify-center rounded-[4px] border-none bg-pink_primary p-3 font-medium leading-[20px] tracking-[0.01em] text-white shadow-[0px_6px_18px_rgba(0,0,0,0.06)] outline-none '
-				>
-					+ Add Post
-				</button>
+				{!v2SupportedNetworks.includes(network) && (
+					<button
+						onClick={handleClick}
+						className='flex h-10 w-full cursor-pointer items-center justify-center rounded-[4px] border-none bg-pink_primary p-3 font-medium leading-[20px] tracking-[0.01em] text-white shadow-[0px_6px_18px_rgba(0,0,0,0.06)] outline-none '
+					>
+						+ Add Post
+					</button>
+				)}
 			</div>
 			{isForumSupportedNetwork(network) ? (
 				<OffChainTabs

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,7 +20,7 @@ import { getLatestActivityAllPosts } from './api/v1/latest-activity/all-posts';
 import { getLatestActivityOffChainPosts } from './api/v1/latest-activity/off-chain-posts';
 import { getLatestActivityOnChainPosts, ILatestActivityPostsListingResponse } from './api/v1/latest-activity/on-chain-posts';
 import { getNetworkSocials } from './api/v1/network-socials';
-import { chainProperties, revampedNetworks } from '~src/global/networkConstants';
+import { chainProperties, v2SupportedNetworks } from '~src/global/networkConstants';
 import { network as AllNetworks } from '~src/global/networkConstants';
 import Gov2LatestActivity from '~src/components/Gov2Home/Gov2LatestActivity';
 import { networkTrackInfo } from '~src/global/post_trackInfo';
@@ -63,7 +63,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
 	const networkRedirect = checkRouteNetworkWithRedirect(network);
 	if (networkRedirect) return networkRedirect;
 
-	if (isOpenGovSupported(network) && !revampedNetworks.includes(network) && !req.headers.referer) {
+	if (isOpenGovSupported(network) && !v2SupportedNetworks.includes(network) && !req.headers.referer) {
 		return {
 			props: {},
 			redirect: {

--- a/pages/post/create.tsx
+++ b/pages/post/create.tsx
@@ -10,6 +10,7 @@ import { getNetworkFromReqHeaders } from '~src/api-utils';
 import Skeleton from '~src/basic-components/Skeleton';
 import SkeletonButton from '~src/basic-components/Skeleton/SkeletonButton';
 import SkeletonInput from '~src/basic-components/Skeleton/SkeletonInput';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 import { ProposalType } from '~src/global/proposalType';
 import SEOHead from '~src/global/SEOHead';
 import { setNetwork } from '~src/redux/network';
@@ -44,6 +45,15 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
 	const network = getNetworkFromReqHeaders(req.headers);
 
 	const networkRedirect = checkRouteNetworkWithRedirect(network);
+
+	if (v2SupportedNetworks.includes(network)) {
+		return {
+			props: {},
+			redirect: {
+				destination: '/'
+			}
+		};
+	}
 	if (networkRedirect) return networkRedirect;
 
 	return { props: { network } };

--- a/pages/sitemap.xml.tsx
+++ b/pages/sitemap.xml.tsx
@@ -6,7 +6,7 @@ import { GetServerSideProps } from 'next';
 import { ProposalType } from '~src/global/proposalType';
 import { firestore_db } from '~src/services/firebaseInit';
 import { getNetworkFromReqHeaders } from '~src/api-utils';
-import { revampedNetworks } from '~src/global/networkConstants';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 const DOMAIN = 'polkassembly.io';
 const PROPOSAL_TYPES = [
@@ -86,7 +86,7 @@ const generateSiteMap = (network: string, urls: string[]): string => {
 				<loc>https://${network}.${DOMAIN}/tech-comm-proposals</loc>
 			</url>
 			${
-				GOV2[network] && !revampedNetworks.includes(network)
+				GOV2[network] && !v2SupportedNetworks.includes(network)
 					? `
 					<url>
 					<loc>https://${network}.${DOMAIN}/opengov</loc>

--- a/pages/treasury-proposals/index.tsx
+++ b/pages/treasury-proposals/index.tsx
@@ -30,6 +30,7 @@ import FilterByStatus from '~src/ui-components/FilterByStatus';
 import SortByDropdownComponent from '~src/ui-components/SortByDropdown';
 import OpenGovTreasuryProposal from '~src/components/OpenGovTreasuryProposal';
 import { isOpenGovSupported } from '~src/global/openGovNetworks';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 const TreasuryOverview = dynamic(() => import('src/components/Home/TreasuryOverview/index'), {
 	ssr: false
@@ -107,7 +108,7 @@ const Treasury: FC<ITreasuryProps> = (props) => {
 					<DiamondIcon className='mr-2 justify-self-center' />
 					Treasury Proposals ({count})
 				</h1>
-				{isCreationOfTreasuryProposalSupported(network) && (
+				{!v2SupportedNetworks.includes(network) && isCreationOfTreasuryProposalSupported(network) && (
 					<OpenGovTreasuryProposal
 						isUsedInReferedumComponent
 						className='flex h-10 cursor-pointer items-center rounded-md bg-pink_primary px-3'

--- a/pages/user-created-bounties/index.tsx
+++ b/pages/user-created-bounties/index.tsx
@@ -22,6 +22,7 @@ import { EUserCreatedBountiesStatuses } from '~src/types';
 import { ErrorState } from '~src/ui-components/UIStates';
 import BountiesTabItems from '~src/components/UserCreatedBounties/BountiesListing/BountiesTabItems';
 import Tooltip from '~src/basic-components/Tooltip';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 interface IUserBountiesListingProps {
 	network: string;
@@ -129,9 +130,11 @@ const UserBountiesListing: FC<IUserBountiesListingProps> = (props) => {
 							/>
 						</Tooltip>
 					</div>
-					<div className='flex gap-2'>
-						<CreateBountyBtn className='hidden md:block' />
-					</div>
+					{!v2SupportedNetworks.includes(network) && (
+						<div className='flex gap-2'>
+							<CreateBountyBtn className='hidden md:block' />
+						</div>
+					)}
 				</div>
 
 				<BountiesTabItems bounties={data?.bounties} />

--- a/src/components/AppLayout/Sidebar.tsx
+++ b/src/components/AppLayout/Sidebar.tsx
@@ -53,7 +53,7 @@ import { isGrantsSupported } from '~src/global/grantsNetworks';
 import { isOpenGovSupported } from '~src/global/openGovNetworks';
 import { networkTrackInfo } from '~src/global/post_trackInfo';
 import { IActiveProposalCount, PostOrigin } from '~src/types';
-import { chainProperties } from '~src/global/networkConstants';
+import { chainProperties, v2SupportedNetworks } from '~src/global/networkConstants';
 import { network as AllNetworks } from '~src/global/networkConstants';
 import { dmSans } from 'pages/_app';
 import PaLogo from './PaLogo';
@@ -2185,13 +2185,15 @@ const Sidebar: React.FC<SidebarProps> = ({
 						</>
 					)}
 				</div>
-				<div
-					className={
-						onchainIdentitySupportedNetwork.includes(network) || delegationSupportedNetworks.includes(network) || (network === 'polkadot' && !sidebarCollapsed) ? '' : 'mt-6'
-					}
-				>
-					<CreateProposalDropdown sidebarCollapsed={sidebarCollapsed} />
-				</div>
+				{!v2SupportedNetworks.includes(network) && (
+					<div
+						className={
+							onchainIdentitySupportedNetwork.includes(network) || delegationSupportedNetworks.includes(network) || (network === 'polkadot' && !sidebarCollapsed) ? '' : 'mt-6'
+						}
+					>
+						<CreateProposalDropdown sidebarCollapsed={sidebarCollapsed} />
+					</div>
+				)}
 				<div
 					className={`hide-scrollbar ${
 						onchainIdentitySupportedNetwork.includes(network) || delegationSupportedNetworks.includes(network) || network === 'polkadot' ? '' : 'mt-7'

--- a/src/components/Bounties/index.tsx
+++ b/src/components/Bounties/index.tsx
@@ -15,6 +15,8 @@ import { chunkArray } from './utils/ChunksArr';
 import BountyProposalActionButton from './bountyProposal';
 import Link from 'next/link';
 import CuratorDashboardButton from '../CuratorDashboard/CuratorDashboardButton';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
+import { useNetworkSelector } from '~src/redux/selectors';
 
 interface IBountiesContainer {
 	extendedData?: IPostsListingResponse;
@@ -22,6 +24,7 @@ interface IBountiesContainer {
 }
 
 const BountiesContainer: FC<IBountiesContainer> = ({ extendedData, activeBountyData }) => {
+	const { network } = useNetworkSelector();
 	const carouselRef1 = useRef<any>(null);
 	const carouselRef2 = useRef<any>(null);
 	const [currentSlide1, setCurrentSlide1] = useState<number>(0);
@@ -43,10 +46,12 @@ const BountiesContainer: FC<IBountiesContainer> = ({ extendedData, activeBountyD
 		<main className='mx-3'>
 			<div className='flex items-center justify-between'>
 				<span className='font-pixelify text-3xl font-bold text-bodyBlue dark:text-blue-dark-high'>Dashboard</span>
-				<div className='flex gap-2'>
-					<BountyProposalActionButton className='hidden md:block' />
-					<CuratorDashboardButton />
-				</div>
+				{!v2SupportedNetworks.includes(network) && (
+					<div className='flex gap-2'>
+						<BountyProposalActionButton className='hidden md:block' />
+						<CuratorDashboardButton />
+					</div>
+				)}
 			</div>
 			<BountiesHeader />
 

--- a/src/components/CuratorDashboard/BountiesCuratorInfo/index.tsx
+++ b/src/components/CuratorDashboard/BountiesCuratorInfo/index.tsx
@@ -23,6 +23,7 @@ import { IChildBounty } from '~src/types';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
 import SkeletonButton from '~src/basic-components/Skeleton/SkeletonButton';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 const CreateChildBountyButton = dynamic(() => import('~src/components/ChildBountyCreation/CreateChildBountyButton'), {
 	loading: () => <SkeletonButton active />,
@@ -240,9 +241,11 @@ const BountiesCuratorInfo: FC<{ handleClick: (num: number) => void }> = ({ handl
 													)}
 												</div>
 											)}
-											<div className='mx-3 mt-4 rounded-lg py-3 text-center'>
-												<CreateChildBountyButton />
-											</div>
+											{!v2SupportedNetworks.includes(network) && (
+												<div className='mx-3 mt-4 rounded-lg py-3 text-center'>
+													<CreateChildBountyButton />
+												</div>
+											)}
 										</div>
 										<div className='mb-5 mt-3 flex justify-end'>
 											{totalBountiesCount > BOUNTIES_LISTING_LIMIT && (

--- a/src/components/CuratorDashboard/PendingRequestManager/PendingRequestTabs/Submission.tsx
+++ b/src/components/CuratorDashboard/PendingRequestManager/PendingRequestTabs/Submission.tsx
@@ -19,6 +19,7 @@ import queueNotification from '~src/ui-components/QueueNotification';
 import { MessageType } from '~src/auth/types';
 import SubmissionAction from '~src/components/Post/GovernanceSideBar/Bounty/Curator/SubmissionAction';
 import MakeChildBountySubmisionModal from '~src/components/Post/GovernanceSideBar/Bounty/Curator/MakeChildBountySubmision';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 interface Props {
 	className?: string;
@@ -160,16 +161,18 @@ const Submission = ({ className, submission, index, updateData, submissions, bou
 					/>
 				)}
 				<Divider className='m-0 mb-2 border-[1px] border-solid border-section-light-container dark:border-separatorDark' />
-				<div className='flex justify-between gap-4 p-2'>
-					<SubmissionAction
-						submission={submission}
-						handleApprove={handleApprove}
-						showRejectModal={setIsRejectModalOpen}
-						handleDelete={handleDelete}
-						handleEditClick={setIsEditModalOpen}
-						isApproveButton
-					/>
-				</div>
+				{!v2SupportedNetworks.includes(network) && (
+					<div className='flex justify-between gap-4 p-2'>
+						<SubmissionAction
+							submission={submission}
+							handleApprove={handleApprove}
+							showRejectModal={setIsRejectModalOpen}
+							handleDelete={handleDelete}
+							handleEditClick={setIsEditModalOpen}
+							isApproveButton
+						/>
+					</div>
+				)}
 			</div>
 
 			{isRejectModalOpen && (

--- a/src/components/DelegationDashboard/BecomeDelegate.tsx
+++ b/src/components/DelegationDashboard/BecomeDelegate.tsx
@@ -5,10 +5,11 @@ import { Alert, Button, Tooltip } from 'antd';
 import dynamic from 'next/dynamic';
 import React, { useState } from 'react';
 import { IDelegationProfileType } from '~src/auth/types';
-import { useUserDetailsSelector } from '~src/redux/selectors';
+import { useNetworkSelector, useUserDetailsSelector } from '~src/redux/selectors';
 import ImageIcon from '~src/ui-components/ImageIcon';
 import Loader from '~src/ui-components/Loader';
 import CloseIcon from '~assets/icons/close-cross-icon.svg';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 const BecomeDelegateModal = dynamic(() => import('../../ui-components/BecomeDelegateModal'), {
 	loading: () => <Loader />,
@@ -26,6 +27,7 @@ interface Props {
 }
 
 const BecomeDelegate = ({ isModalOpen, setIsModalOpen, profileDetails, userBio, setUserBio, onchainUsername }: Props) => {
+	const { network } = useNetworkSelector();
 	const currentUser = useUserDetailsSelector();
 	const [isBecomedelegateVisible, setsBecomedelegateVisible] = useState(true);
 	const showModal = () => {
@@ -43,15 +45,15 @@ const BecomeDelegate = ({ isModalOpen, setIsModalOpen, profileDetails, userBio, 
 						<div className='flex items-center justify-between'>
 							<span className='text-xl font-semibold text-bodyBlue dark:text-white'>How to Delegate on Polkassembly</span>
 							<div className='flex items-center space-x-5'>
-								<Button
-									onClick={showModal}
-									disabled={!currentUser.id || !currentUser.loginAddress}
-									className={`border-pink_primary bg-pink_primary font-medium font-semibold text-white dark:text-black ${
-										(!currentUser.id || !currentUser.loginAddress) && 'opacity-50'
-									}`}
-								>
-									{!currentUser.id ? <Tooltip title='Please Login to continue'>Become a Delegate</Tooltip> : 'Become a Delegate'}
-								</Button>
+								{!v2SupportedNetworks.includes(network) && (
+									<Button
+										onClick={showModal}
+										disabled={!currentUser.id || !currentUser.loginAddress}
+										className={`border-pink_primary bg-pink_primary font-semibold text-white dark:text-black ${(!currentUser.id || !currentUser.loginAddress) && 'opacity-50'}`}
+									>
+										{!currentUser.id ? <Tooltip title='Please Login to continue'>Become a Delegate</Tooltip> : 'Become a Delegate'}
+									</Button>
+								)}
 								<span onClick={handleNotificationNudgeClose}>
 									<CloseIcon className='mt-1 cursor-pointer dark:text-white' />
 								</span>

--- a/src/components/DelegationDashboard/DelegationProfile.tsx
+++ b/src/components/DelegationDashboard/DelegationProfile.tsx
@@ -11,12 +11,13 @@ import dynamic from 'next/dynamic';
 import CustomButton from '~src/basic-components/buttons/CustomButton';
 import Address from '~src/ui-components/Address';
 import SocialsHandle from '../../ui-components/SocialsHandle';
-import { useUserDetailsSelector } from '~src/redux/selectors';
+import { useNetworkSelector, useUserDetailsSelector } from '~src/redux/selectors';
 import SkeletonAvatar from '~src/basic-components/Skeleton/SkeletonAvatar';
 import Image from 'next/image';
 import ExpandableMarkdown from '../Post/Tabs/ExpandableMarkdown';
 import { useTheme } from 'next-themes';
 import useIsMobile from '~src/hooks/useIsMobile';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 const ImageComponent = dynamic(() => import('src/components/ImageComponent'), {
 	loading: () => <SkeletonAvatar active />,
@@ -45,6 +46,7 @@ interface Props {
 
 const DelegationProfile = ({ isSearch, className, profileDetails, userBio, setUserBio, setIsModalOpen, identity }: Props) => {
 	const { theme } = useTheme();
+	const { network } = useNetworkSelector();
 	const userProfile = useUserDetailsSelector();
 	const isMobile = useIsMobile();
 	const { delegationDashboardAddress: address } = userProfile;
@@ -84,7 +86,7 @@ const DelegationProfile = ({ isSearch, className, profileDetails, userBio, setUs
 							className='flex h-[105px] w-[105px] items-center justify-center bg-transparent max-sm:mx-auto '
 							iconClassName='flex items-center justify-center text-[#FCE5F2] text-5xl w-full h-full rounded-full'
 						/>
-						{!isSearch && (
+						{!isSearch && !v2SupportedNetworks.includes(network) && (
 							<div className='absolute right-6 top-[34px] flex items-start justify-start gap-2.5 text-pink_primary sm:hidden'>
 								{userBio || bio ? (
 									<div className='flex space-x-2'>
@@ -160,7 +162,7 @@ const DelegationProfile = ({ isSearch, className, profileDetails, userBio, setUs
 					)}
 				</div>
 
-				{!isSearch && (
+				{!isSearch && !v2SupportedNetworks.includes(network) && (
 					<div className='hidden items-start justify-start gap-2.5 text-pink_primary sm:flex'>
 						<span className='flex items-center gap-6'>
 							<ChatWithDelegates />

--- a/src/components/DelegationDashboard/DelegationTabs.tsx
+++ b/src/components/DelegationDashboard/DelegationTabs.tsx
@@ -12,7 +12,7 @@ import { Button, TabsProps } from 'antd';
 import DelegationProfile from '~src/components/DelegationDashboard/DelegationProfile';
 import DashboardTrackListing from './TracksListing';
 import nextApiClientFetch from '~src/util/nextApiClientFetch';
-import { useUserDetailsSelector } from '~src/redux/selectors';
+import { useNetworkSelector, useUserDetailsSelector } from '~src/redux/selectors';
 import { IGetProfileWithAddressResponse } from 'pages/api/v1/auth/data/profileWithAddress';
 import { IDelegationProfileType } from '~src/auth/types';
 import { DeriveAccountRegistration } from '@polkadot/api-derive/types';
@@ -22,6 +22,7 @@ import { useTheme } from 'next-themes';
 import TotalDelegationDataSmall from './smallScreenComponents/TotalDelegationDataSmall';
 import BecomeDelegateModal from '~src/ui-components/BecomeDelegateModal';
 import useIsMobile from '~src/hooks/useIsMobile';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 interface Props {
 	className?: string;
@@ -32,6 +33,7 @@ interface Props {
 
 const DelegationTabs = ({ className, isLoggedOut, identity }: Props) => {
 	const userProfile = useUserDetailsSelector();
+	const { network } = useNetworkSelector();
 	const { api, apiReady } = useApiContext();
 	const isMobile = useIsMobile();
 	const { delegationDashboardAddress } = userProfile;
@@ -109,14 +111,16 @@ const DelegationTabs = ({ className, isLoggedOut, identity }: Props) => {
 		{
 			children: (
 				<>
-					<BecomeDelegate
-						isModalOpen={isModalOpen}
-						setIsModalOpen={setIsModalOpen}
-						profileDetails={profileDetails}
-						userBio={userBio}
-						setUserBio={setUserBio}
-						onchainUsername={identity?.display || identity?.legal || ''}
-					/>
+					{!v2SupportedNetworks.includes(network) && (
+						<BecomeDelegate
+							isModalOpen={isModalOpen}
+							setIsModalOpen={setIsModalOpen}
+							profileDetails={profileDetails}
+							userBio={userBio}
+							setUserBio={setUserBio}
+							onchainUsername={identity?.display || identity?.legal || ''}
+						/>
+					)}
 					<DelegationProfile
 						className='rounded-xxl bg-white px-6 py-5 drop-shadow-md dark:bg-section-dark-overlay'
 						profileDetails={profileDetails}

--- a/src/components/Listing/Tracks/AboutTrackCard.tsx
+++ b/src/components/Listing/Tracks/AboutTrackCard.tsx
@@ -4,7 +4,7 @@
 
 import { Divider } from 'antd';
 import BN from 'bn.js';
-import { network as AllNetworks } from '~src/global/networkConstants';
+import { network as AllNetworks, v2SupportedNetworks } from '~src/global/networkConstants';
 import React, { FC, useEffect, useState } from 'react';
 import formatBnBalance from 'src/util/formatBnBalance';
 import { chainProperties } from '~src/global/networkConstants';
@@ -298,21 +298,22 @@ const AboutTrackCard: FC<IAboutTrackCardProps> = (props) => {
 				<div className='flex justify-end xs:hidden md:flex md:p-1'>
 					<div className='flex gap-4'>
 						{delegationSupportedNetworks.includes(network) && !delegatedTo && <DelegateModal trackNum={trackMetaData?.trackId} />}
-						{network === 'polkadot' && trackName == 'FellowshipAdmin' && (
+						{!v2SupportedNetworks.includes(network) && network === 'polkadot' && trackName == 'FellowshipAdmin' && (
 							<div className=''>
 								<AmbassadorActionButtons />
 							</div>
 						)}
-						{['root', 'ReferendumCanceller', 'ReferendumKiller', 'StakingAdmin', 'AuctionAdmin', 'WishForChange', 'FastGeneralAdmin'].includes(trackName) && (
-							<ProposalActionButtons
-								isCreateProposal={
-									trackName === 'root' || trackName === 'StakingAdmin' || trackName === 'AuctionAdmin' || trackName === 'WishForChange' || trackName === 'FastGeneralAdmin'
-								}
-								isCancelProposal={trackName === 'ReferendumCanceller'}
-								isKillProposal={trackName === 'ReferendumKiller'}
-							/>
-						)}
-						{trackMetaData?.group === 'Treasury' && treasuryProposalCreationAllowedNetwork.includes(network) && (
+						{!v2SupportedNetworks.includes(network) &&
+							['root', 'ReferendumCanceller', 'ReferendumKiller', 'StakingAdmin', 'AuctionAdmin', 'WishForChange', 'FastGeneralAdmin'].includes(trackName) && (
+								<ProposalActionButtons
+									isCreateProposal={
+										trackName === 'root' || trackName === 'StakingAdmin' || trackName === 'AuctionAdmin' || trackName === 'WishForChange' || trackName === 'FastGeneralAdmin'
+									}
+									isCancelProposal={trackName === 'ReferendumCanceller'}
+									isKillProposal={trackName === 'ReferendumKiller'}
+								/>
+							)}
+						{trackMetaData?.group === 'Treasury' && !v2SupportedNetworks.includes(network) && treasuryProposalCreationAllowedNetwork.includes(network) && (
 							<CustomButton
 								className='delegation-buttons'
 								variant='primary'
@@ -328,7 +329,7 @@ const AboutTrackCard: FC<IAboutTrackCardProps> = (props) => {
 					</div>
 				</div>
 			</article>
-			{delegatedTo && (
+			{!!delegatedTo && (
 				<Alert
 					message={
 						<span className='flex items-center text-[13px]'>
@@ -496,12 +497,12 @@ const AboutTrackCard: FC<IAboutTrackCardProps> = (props) => {
 				<article className='justify-end px-4 pb-4 pt-0 xs:flex md:hidden md:p-4'>
 					<div className='flex flex-wrap gap-2'>
 						{delegationSupportedNetworks.includes(network) && <DelegateModal trackNum={trackMetaData?.trackId} />}
-						{network === 'polkadot' && trackName == 'FellowshipAdmin' && (
+						{!v2SupportedNetworks.includes(network) && network === 'polkadot' && trackName == 'FellowshipAdmin' && (
 							<div>
 								<AmbassadorActionButtons />
 							</div>
 						)}
-						{trackMetaData?.group === 'Treasury' && treasuryProposalCreationAllowedNetwork?.includes(network) && (
+						{trackMetaData?.group === 'Treasury' && !v2SupportedNetworks.includes(network) && treasuryProposalCreationAllowedNetwork?.includes(network) && (
 							<CustomButton
 								className='delegation-buttons'
 								variant='primary'

--- a/src/components/Post/Comment/CommentsContainer.tsx
+++ b/src/components/Post/Comment/CommentsContainer.tsx
@@ -52,6 +52,7 @@ import { dmSans } from 'pages/_app';
 import Skeleton from '~src/basic-components/Skeleton';
 import nextApiClientFetch from '~src/util/nextApiClientFetch';
 import getIdentityInformation from '~src/auth/utils/getIdentityInformation';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 export function getStatus(type: string) {
 	if (['DemocracyProposal'].includes(type)) {
@@ -483,10 +484,12 @@ const CommentsContainer: FC<ICommentsContainerProps> = (props) => {
 							showIcon
 						/>
 					) : (
-						<PostCommentForm
-							className='mb-2'
-							setCurrentState={handleCurrentCommentAndTimeline}
-						/>
+						!v2SupportedNetworks.includes(network) && (
+							<PostCommentForm
+								className='mb-2'
+								setCurrentState={handleCurrentCommentAndTimeline}
+							/>
+						)
 					)}
 				</>
 			) : (

--- a/src/components/Post/Comment/EditableCommentContent.tsx
+++ b/src/components/Post/Comment/EditableCommentContent.tsx
@@ -62,6 +62,7 @@ import classNames from 'classnames';
 import getMarkdownContent from '~src/api-utils/getMarkdownContent';
 import MarkdownEditor from '~src/components/Editor/MarkdownEditor';
 import { MDXEditorMethods } from '@mdxeditor/editor';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 interface IEditableCommentContentProps {
 	userId: number;
@@ -489,6 +490,7 @@ const EditableCommentContent: FC<IEditableCommentContentProps> = (props) => {
 	};
 
 	const canEditComment = useCallback(async () => {
+		if (v2SupportedNetworks.includes(network)) return;
 		if (comment.isDeleted) {
 			setIsEditable(false);
 			return;
@@ -507,7 +509,7 @@ const EditableCommentContent: FC<IEditableCommentContentProps> = (props) => {
 			}
 		}
 		return setIsEditable(false);
-	}, [addresses, id, loginAddress, proposer, userId, comment.isDeleted]);
+	}, [addresses, id, loginAddress, proposer, userId, comment.isDeleted, network]);
 
 	const deleteComment = async () => {
 		const oldComments = comments;
@@ -600,7 +602,7 @@ const EditableCommentContent: FC<IEditableCommentContentProps> = (props) => {
 					)
 			  }
 			: null,
-		isEditable
+		isEditable && !v2SupportedNetworks.includes(network)
 			? {
 					key: 4,
 					label: (
@@ -771,7 +773,7 @@ const EditableCommentContent: FC<IEditableCommentContentProps> = (props) => {
 								comment_reactions={comment.comment_reactions}
 								importedReactions={props.isSubsquareUser}
 							/>
-							{id && (
+							{id && !v2SupportedNetworks.includes(network) && (
 								<Button
 									disabled={props.disableEdit || !isCommentAllowed}
 									className={classNames(

--- a/src/components/Post/Comment/EditableReplyContent.tsx
+++ b/src/components/Post/Comment/EditableReplyContent.tsx
@@ -40,7 +40,7 @@ import { ProposalType } from '~src/global/proposalType';
 import getMarkdownContent from '~src/api-utils/getMarkdownContent';
 import MarkdownEditor from '~src/components/Editor/MarkdownEditor';
 import { MDXEditorMethods } from '@mdxeditor/editor';
-
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 interface Props {
 	userId: number;
 	className?: string;
@@ -156,6 +156,7 @@ const EditableReplyContent = ({
 	};
 
 	const canEditComment = useCallback(async () => {
+		if (v2SupportedNetworks.includes(network)) return;
 		if (id === userId) {
 			return setIsEditable(true);
 		}
@@ -170,7 +171,7 @@ const EditableReplyContent = ({
 			}
 		}
 		return setIsEditable(false);
-	}, [addresses, id, loginAddress, proposer, userId]);
+	}, [addresses, id, loginAddress, proposer, userId, network]);
 
 	const handleSave = async () => {
 		const newContent = editableReplyContent;
@@ -584,7 +585,7 @@ const EditableReplyContent = ({
 					)
 			  }
 			: null,
-		id === userId
+		id === userId && !v2SupportedNetworks.includes(network)
 			? {
 					key: 2,
 					label: (
@@ -694,7 +695,7 @@ const EditableReplyContent = ({
 								isReactionOnReply={isReactionOnReply}
 							/>
 							<div className='item-center flex flex-wrap gap-3'>
-								{id ? (
+								{id && !v2SupportedNetworks.includes(network) ? (
 									reply.reply_source === 'subsquare' ? (
 										<Tooltip
 											title='Reply are disabled for imported comments.'

--- a/src/components/Post/GovernanceSideBar/Bounty/BountyChildBounties.tsx
+++ b/src/components/Post/GovernanceSideBar/Bounty/BountyChildBounties.tsx
@@ -22,6 +22,7 @@ import getBountiesCustomStatuses from '~src/util/getBountiesCustomStatuses';
 import { EBountiesStatuses } from '~src/components/Bounties/BountiesListing/types/types';
 import { isBountiesDashboardSupportedNetwork } from '~src/components/Bounties/utils/isBountiesDashboardSupportedNetwork';
 import { usePostDataContext } from '~src/context';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 interface IBountyChildBountiesProps {
 	bountyId?: number | string | null;
@@ -113,7 +114,7 @@ const BountyChildBounties: FC<IBountyChildBountiesProps> = (props) => {
 					  )
 					: !loading && <PostEmptyState />}
 
-				{canCreateChildBounty() && <CreateChildBountyButton className='mt-4' />}
+				{canCreateChildBounty() && !v2SupportedNetworks.includes(network) && <CreateChildBountyButton className='mt-4' />}
 				<PaginationContainer className='mt-4 flex items-center justify-end'>
 					<Pagination
 						theme={theme}

--- a/src/components/Post/GovernanceSideBar/Bounty/Curator/Submissions.tsx
+++ b/src/components/Post/GovernanceSideBar/Bounty/Curator/Submissions.tsx
@@ -22,6 +22,7 @@ import CustomButton from '~src/basic-components/buttons/CustomButton';
 import SubmissionAction from './SubmissionAction';
 import Alert from '~src/basic-components/Alert';
 import classNames from 'classnames';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 interface IBountyChildBountiesProps {
 	bountyId?: number | string | null;
@@ -270,13 +271,15 @@ const Submissions: FC<IBountyChildBountiesProps> = (props) => {
 											className='mb-2'
 										/>
 									)}
-									<div className='flex w-full'>
-										<SubmissionAction
-											submission={submission}
-											handleDelete={handleDelete}
-											handleEditClick={handleEditClick}
-										/>
-									</div>
+									{!v2SupportedNetworks.includes(network) && (
+										<div className='flex w-full'>
+											<SubmissionAction
+												submission={submission}
+												handleDelete={handleDelete}
+												handleEditClick={handleEditClick}
+											/>
+										</div>
+									)}
 								</div>
 							</div>
 						))

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -44,7 +44,7 @@ import Skeleton from '~src/basic-components/Skeleton';
 import { EAllowedCommentor } from '~src/types';
 import { useRouter } from 'next/router';
 import PostAISummary from './PostAISummary';
-
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 const PostDescription = dynamic(() => import('./Tabs/PostDescription'), {
 	loading: () => <Skeleton active />,
 	ssr: false
@@ -108,6 +108,7 @@ function formatDuration(duration: any) {
 }
 
 const Post: FC<IPostProps> = (props) => {
+	const { network } = useNetworkSelector();
 	const { className, post, trackName, proposalType } = props;
 	const { resolvedTheme: theme } = useTheme();
 	const { id, addresses, loginAddress } = useUserDetailsSelector();
@@ -115,7 +116,6 @@ const Post: FC<IPostProps> = (props) => {
 	const toggleEdit = () => setIsEditing(!isEditing);
 	const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
 	const [canEdit, setCanEdit] = useState(false);
-	const { network } = useNetworkSelector();
 	const [duration, setDuration] = useState(dayjs.duration(0));
 	const [totalAuditCount, setTotalAuditCount] = useState<number>(0);
 	const [totalVideoCount, setTotalVideoCount] = useState<number>(0);
@@ -149,12 +149,14 @@ const Post: FC<IPostProps> = (props) => {
 
 	const handleCanEdit = useCallback(async () => {
 		const { post_id, proposer } = post;
+		const network = getNetwork();
+
+		if (v2SupportedNetworks.includes(network)) return;
 
 		setCanEdit(post.user_id === id);
 		const substrateAddress = getSubstrateAddress(proposer);
 
 		let isProposer = proposer && addresses?.includes(substrateAddress || proposer);
-		const network = getNetwork();
 		if (network == 'moonbeam' && proposalType == ProposalType.DEMOCRACY_PROPOSALS && post_id == 23) {
 			isProposer = addresses?.includes('0xbb1e1722513a8fa80f7593617bb0113b1258b7f1');
 		}

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -37,6 +37,7 @@ import getSubstrateAddress from '~src/util/getSubstrateAddress';
 import nextApiClientFetch from '~src/util/nextApiClientFetch';
 import MarkdownEditor from '../Editor/MarkdownEditor';
 import { MDXEditorMethods } from '@mdxeditor/editor';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 interface Props {
 	className?: string;
@@ -90,6 +91,7 @@ const Profile = ({ className, profileDetails }: Props): JSX.Element => {
 			}
 
 			accounts.forEach((account) => {
+				if (v2SupportedNetworks.includes(network)) return;
 				if (getEncodedAddress(account.address, network) === address) {
 					setCanEdit(true);
 				}

--- a/src/components/Search/SearchProfile.tsx
+++ b/src/components/Search/SearchProfile.tsx
@@ -10,13 +10,14 @@ import { CopyIcon, EditIcon } from '~src/ui-components/CustomIcons';
 import MessengerIcon from '~assets/icons/messenger.svg';
 import EditProfileModal from '~src/components/UserProfile/EditProfile';
 import dynamic from 'next/dynamic';
-import { useUserDetailsSelector } from '~src/redux/selectors';
+import { useNetworkSelector, useUserDetailsSelector } from '~src/redux/selectors';
 import CustomButton from '~src/basic-components/buttons/CustomButton';
 import Tooltip from '~src/basic-components/Tooltip';
 import { socialLinks } from '~src/components/UserProfile/Socials';
 import Address from '~src/ui-components/Address';
 import SocialLink from '~src/ui-components/SocialLinks';
 import SkeletonAvatar from '~src/basic-components/Skeleton/SkeletonAvatar';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 const ImageComponent = dynamic(() => import('src/components/ImageComponent'), {
 	loading: () => <SkeletonAvatar active />,
@@ -32,6 +33,7 @@ interface Props {
 
 const SearchProfile = ({ username, address, isSearch, className }: Props) => {
 	const userProfile = useUserDetailsSelector();
+	const { network } = useNetworkSelector();
 	const [profileDetails, setProfileDetails] = useState<ProfileDetailsResponse>({
 		achievement_badges: [],
 		addresses: [],
@@ -111,13 +113,19 @@ const SearchProfile = ({ username, address, isSearch, className }: Props) => {
 					{!bio ? (
 						<h2
 							className={`mt-2 text-sm font-normal text-[#576D8BCC] dark:text-white ${username === userProfile.username && 'cursor-pointer'}`}
-							onClick={() => setOpenEditModal(true)}
+							onClick={() => {
+								if (v2SupportedNetworks.includes(network)) return;
+								setOpenEditModal(true);
+							}}
 						>
 							{username === userProfile.username ? 'Click here to add bio' : 'No Bio'}
 						</h2>
 					) : (
 						<h2
-							onClick={() => setOpenEditModal(true)}
+							onClick={() => {
+								if (v2SupportedNetworks.includes(network)) return;
+								setOpenEditModal(true);
+							}}
 							className={`mt-2 cursor-pointer text-sm font-normal tracking-[0.01em] text-bodyBlue dark:text-blue-dark-high ${
 								username === userProfile.username && 'cursor-pointer'
 							}`}
@@ -155,23 +163,25 @@ const SearchProfile = ({ username, address, isSearch, className }: Props) => {
 					>
 						<MessengerIcon />
 					</Tooltip>
-					<span>
-						{username === userProfile.username && (
-							<CustomButton
-								onClick={() => setOpenEditModal(true)}
-								height={40}
-								width={87}
-								variant='default'
-								className='max-lg:w-auto'
-							>
-								<EditIcon className='text-sm tracking-wide text-pink_primary ' />
-								<span className='max-md:hidden'>Edit</span>
-							</CustomButton>
-						)}
-					</span>
+					{!v2SupportedNetworks.includes(network) && (
+						<span>
+							{username === userProfile.username && (
+								<CustomButton
+									onClick={() => setOpenEditModal(true)}
+									height={40}
+									width={87}
+									variant='default'
+									className='max-lg:w-auto'
+								>
+									<EditIcon className='text-sm tracking-wide text-pink_primary ' />
+									<span className='max-md:hidden'>Edit</span>
+								</CustomButton>
+							)}
+						</span>
+					)}
 				</div>
 			)}
-			{openEditModal && username === userProfile.username && (
+			{openEditModal && username === userProfile.username && !v2SupportedNetworks.includes(network) && (
 				<EditProfileModal
 					openModal={openEditModal}
 					setOpenModal={setOpenEditModal}

--- a/src/components/UserCreatedBounties/BountiesListing/BountiesTabItems.tsx
+++ b/src/components/UserCreatedBounties/BountiesListing/BountiesTabItems.tsx
@@ -10,12 +10,15 @@ import { EUserCreatedBountiesStatuses, IUserCreatedBounty } from '~src/types';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import CreateBountyBtn from '../CreateBountyBtn';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
+import { useNetworkSelector } from '~src/redux/selectors';
 
 interface IBountiesTabItemsProps {
 	bounties: IUserCreatedBounty[];
 }
 
 const BountiesTabItems: FC<IBountiesTabItemsProps> = (props) => {
+	const { network } = useNetworkSelector();
 	const { resolvedTheme: theme } = useTheme();
 	const router = useRouter();
 	const isMobile = typeof window !== 'undefined' && window.innerWidth < 640;
@@ -57,9 +60,8 @@ const BountiesTabItems: FC<IBountiesTabItemsProps> = (props) => {
 						<div className='text-lg font-semibold text-blue-light-high dark:text-blue-dark-high'>Nothing to see here</div>
 						<span className='mt-1 flex gap-1 text-sm text-blue-light-medium dark:text-blue-dark-medium'>
 							No Bounties have been created yet.
-							{!isMobile && (
+							{!isMobile && !v2SupportedNetworks.includes(network) && (
 								<>
-									{' '}
 									<CreateBountyBtn
 										className='hidden md:block'
 										isUsedInTable={true}

--- a/src/components/UserCreatedBounties/UserBountyPage/BountyPost/index.tsx
+++ b/src/components/UserCreatedBounties/UserBountyPage/BountyPost/index.tsx
@@ -10,7 +10,7 @@ import { IUserCreatedBounty } from '~src/types';
 import Markdown from '~src/ui-components/Markdown';
 import NameLabel from '~src/ui-components/NameLabel';
 import StatusTag from '~src/ui-components/StatusTag';
-import { chainProperties } from '~src/global/networkConstants';
+import { chainProperties, v2SupportedNetworks } from '~src/global/networkConstants';
 import { useCurrentTokenDataSelector, useNetworkSelector, useUserDetailsSelector } from '~src/redux/selectors';
 import formatBnBalance from '~src/util/formatBnBalance';
 import TagsModal from '~src/ui-components/TagsModal';
@@ -143,12 +143,14 @@ const BountyPost = ({ post }: { post: IUserCreatedBounty }) => {
 					</button>
 				)}
 			</div>
-			<CreateBountyModal
-				openCreateBountyModal={openCreateBountyModal}
-				setOpenCreateBountyModal={setOpenCreateBountyModal}
-				isUsedForEdit={true}
-				postInfo={post}
-			/>
+			{!v2SupportedNetworks.includes(network) && (
+				<CreateBountyModal
+					openCreateBountyModal={openCreateBountyModal}
+					setOpenCreateBountyModal={setOpenCreateBountyModal}
+					isUsedForEdit={true}
+					postInfo={post}
+				/>
+			)}
 		</section>
 	);
 };

--- a/src/components/UserProfile/ProfileDelegationsCard.tsx
+++ b/src/components/UserProfile/ProfileDelegationsCard.tsx
@@ -26,6 +26,7 @@ import { parseBalance } from '../Post/GovernanceSideBar/Modal/VoteData/utils/par
 import Markdown from '~src/ui-components/Markdown';
 import { delegationSupportedNetworks } from '../Post/Tabs/PostStats/util/constants';
 import BN from 'bn.js';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 const BecomeDelegateModal = dynamic(() => import('~src/ui-components/BecomeDelegateModal'), {
 	ssr: false
@@ -265,7 +266,7 @@ const ProfileDelegationsCard = ({ className, userProfile, addressWithIdentity, o
 							<span>Delegate</span>
 						</CustomButton>
 					)}
-					{userProfile?.user_id === loginId && !!(username || '')?.length && !!delegationMandate?.length && (
+					{userProfile?.user_id === loginId && !!(username || '')?.length && !!delegationMandate?.length && !v2SupportedNetworks.includes(network) && (
 						<span
 							className='flex cursor-pointer items-center'
 							onClick={() => {
@@ -277,7 +278,7 @@ const ProfileDelegationsCard = ({ className, userProfile, addressWithIdentity, o
 							<span className='m-0 p-0 text-pink_primary'>Edit</span>
 						</span>
 					)}
-					{userProfile?.user_id === loginId && !!(username || '')?.length && !delegationMandate?.length && (
+					{userProfile?.user_id === loginId && !!(username || '')?.length && !delegationMandate?.length && !v2SupportedNetworks.includes(network) && (
 						<CustomButton
 							className='delegation-buttons border-none shadow-none'
 							variant='default'

--- a/src/components/UserProfile/ProfileHeader.tsx
+++ b/src/components/UserProfile/ProfileHeader.tsx
@@ -19,6 +19,7 @@ import getEncodedAddress from '~src/util/getEncodedAddress';
 import { DollarIcon } from '~src/ui-components/CustomIcons';
 import { delegationSupportedNetworks } from '../Post/Tabs/PostStats/util/constants';
 import FollowButton from '../Follow/FollowButton';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 const Tipping = dynamic(() => import('~src/components/Tipping'), {
 	ssr: false
@@ -51,64 +52,67 @@ const ProfileHeader = ({ className, userProfile, profileDetails, setProfileDetai
 	return (
 		<div className={classNames(className, 'wallet-info-board gap mt-[-25px] flex rounded-b-[20px] max-lg:absolute max-lg:left-0 max-lg:w-[99.3vw] lg:top-[80px]')}>
 			<div className='profile-header mt-0 flex h-[192px] w-full items-end justify-end'>
-				<div className='flex w-full items-center justify-end p-4 sm:p-8'>
-					{username === userProfile.username ? (
-						<div>
-							<EditProfileModal
-								setProfileDetails={setProfileDetails}
-								data={profileDetails}
-							/>
-						</div>
-					) : (
-						<div className='flex gap-3'>
-							{!TippingUnavailableNetworks.includes(network) && (
-								<CustomButton
-									variant='primary'
-									shape='circle'
-									className={`dark:bg-pink-primary rounded-full border-[1px] border-pink_primary bg-pink_primary px-4 py-2.5 text-white max-md:p-3 ${
-										disableState && 'cursor-not-allowed opacity-50'
-									}`}
-									onClick={() => {
-										if (disableState) return;
-										setOpenTipModal(true);
-										dispatch(setReceiver(addressWithIdentity || ''));
-									}}
-									disabled={!id}
-								>
-									<div className='flex items-center gap-1.5'>
-										<DollarIcon className='text-lg' />
-										<span className='max-md:hidden'>Tip User</span>
-									</div>
-								</CustomButton>
-							)}
-							{!['moonbeam', 'moonbase', 'moonriver'].includes(network) && isOpenGovSupported(network) && (
-								<CustomButton
-									variant='primary'
-									shape='circle'
-									className={`dark:bg-pink-primary rounded-full border-[1px] border-pink_primary bg-pink_primary px-4 py-2.5 text-white max-md:p-3 ${
-										disableState && 'cursor-not-allowed opacity-50'
-									}`}
-									onClick={() => {
-										if (disableState) return;
-										setOpenDelegateModal(true);
-									}}
-									disabled={!id}
-								>
-									<Image
-										src='/assets/icons/white-delegated-profile.svg'
-										className='mr-1 rounded-full'
-										height={20}
-										width={20}
-										alt='edit logo'
-									/>
-									<span className='max-md:hidden'>Delegate</span>
-								</CustomButton>
-							)}
-							<FollowButton userId={userProfile.user_id} />
-						</div>
-					)}
-				</div>
+				{!v2SupportedNetworks.includes(network) && (
+					<div className='flex w-full items-center justify-end p-4 sm:p-8'>
+						{username === userProfile.username ? (
+							<div>
+								<EditProfileModal
+									setProfileDetails={setProfileDetails}
+									data={profileDetails}
+								/>
+							</div>
+						) : (
+							<div className='flex gap-3'>
+								{!TippingUnavailableNetworks.includes(network) && (
+									<CustomButton
+										variant='primary'
+										shape='circle'
+										className={`dark:bg-pink-primary rounded-full border-[1px] border-pink_primary bg-pink_primary px-4 py-2.5 text-white max-md:p-3 ${
+											disableState && 'cursor-not-allowed opacity-50'
+										}`}
+										onClick={() => {
+											if (disableState) return;
+											setOpenTipModal(true);
+											dispatch(setReceiver(addressWithIdentity || ''));
+										}}
+										disabled={!id}
+									>
+										<div className='flex items-center gap-1.5'>
+											<DollarIcon className='text-lg' />
+											<span className='max-md:hidden'>Tip User</span>
+										</div>
+									</CustomButton>
+								)}
+								{!['moonbeam', 'moonbase', 'moonriver'].includes(network) && isOpenGovSupported(network) && (
+									<CustomButton
+										variant='primary'
+										shape='circle'
+										className={`dark:bg-pink-primary rounded-full border-[1px] border-pink_primary bg-pink_primary px-4 py-2.5 text-white max-md:p-3 ${
+											disableState && 'cursor-not-allowed opacity-50'
+										}`}
+										onClick={() => {
+											if (disableState) return;
+											setOpenDelegateModal(true);
+										}}
+										disabled={!id}
+									>
+										<Image
+											src='/assets/icons/white-delegated-profile.svg'
+											className='mr-1 rounded-full'
+											height={20}
+											width={20}
+											alt='edit logo'
+										/>
+										<span className='max-md:hidden'>Delegate</span>
+									</CustomButton>
+								)}
+								<FollowButton userId={userProfile.user_id} />
+							</div>
+						)}
+					</div>
+				)}
 			</div>
+
 			{!TippingUnavailableNetworks.includes(network) && (
 				<Tipping
 					open={openTipModal}

--- a/src/components/UserProfile/ProfileLinkedAddresses.tsx
+++ b/src/components/UserProfile/ProfileLinkedAddresses.tsx
@@ -23,6 +23,7 @@ import dynamic from 'next/dynamic';
 import { onchainIdentitySupportedNetwork } from '../AppLayout';
 import getIdentityInformation from '~src/auth/utils/getIdentityInformation';
 import CustomButton from '~src/basic-components/buttons/CustomButton';
+import { v2SupportedNetworks } from '~src/global/networkConstants';
 
 const OnchainIdentity = dynamic(() => import('~src/components/OnchainIdentity'), {
 	ssr: false
@@ -150,7 +151,7 @@ const ProfileLinkedAddresses = ({ className, userProfile, selectedAddresses, set
 					Linked Addresses
 				</span>
 
-				{userProfile?.user_id === id && (
+				{userProfile?.user_id === id && !v2SupportedNetworks.includes(network) && (
 					<Popover
 						destroyTooltipOnHide
 						zIndex={1056}

--- a/src/components/UserProfile/ProfileOverview.tsx
+++ b/src/components/UserProfile/ProfileOverview.tsx
@@ -14,7 +14,7 @@ import EditProfileModal from './EditProfile';
 import { DeriveAccountRegistration } from '@polkadot/api-derive/types';
 import { delegationSupportedNetworks } from '../Post/Tabs/PostStats/util/constants';
 import { EditIcon } from '~src/ui-components/CustomIcons';
-import { chainProperties } from '~src/global/networkConstants';
+import { chainProperties, v2SupportedNetworks } from '~src/global/networkConstants';
 
 const ProfileTippingCard = dynamic(() => import('./ProfileTippingCard'), {
 	ssr: false
@@ -77,7 +77,7 @@ const ProfileOverview = ({
 							<span
 								className={classNames('text-sm font-normal', !bio?.length && 'cursor-pointer ')}
 								onClick={() => {
-									if (username !== userProfile.username) return;
+									if (username !== userProfile.username || v2SupportedNetworks.includes(network)) return;
 									setOpenEditModal(true);
 								}}
 							>
@@ -148,7 +148,7 @@ const ProfileOverview = ({
 										/>
 										About
 									</span>
-									{username === userProfile?.username && (
+									{username === userProfile?.username && !v2SupportedNetworks.includes(network) && (
 										<span
 											className='flex cursor-pointer items-center'
 											onClick={() => {

--- a/src/global/networkConstants.ts
+++ b/src/global/networkConstants.ts
@@ -2083,4 +2083,4 @@ export const addressPrefix: Record<string, number> = {
 	curio: 777
 };
 
-export const revampedNetworks = [network.WESTEND];
+export const v2SupportedNetworks = [network.POLKADOT, network.WESTEND];

--- a/src/ui-components/NetworkDropdown.tsx
+++ b/src/ui-components/NetworkDropdown.tsx
@@ -5,7 +5,7 @@
 import { Col, Row, Dropdown } from 'antd';
 import Image from 'next/image';
 import React, { FC, useState } from 'react';
-import { chainProperties, network, revampedNetworks } from 'src/global/networkConstants';
+import { chainProperties, network, v2SupportedNetworks } from 'src/global/networkConstants';
 import { ArrowDownIcon } from './CustomIcons';
 import { isOpenGovSupported } from '~src/global/openGovNetworks';
 import { useRouter } from 'next/router';
@@ -38,7 +38,7 @@ for (const key of Object.keys(network)) {
 		? `https://${key}.polkassembly.network`
 		: `https://${key === 'POLYMESHTEST' ? 'polymesh-test' : keyVal}.polkassembly.io`;
 
-	if (isOpenGovSupported(keyVal) && !revampedNetworks.includes(keyVal)) {
+	if (isOpenGovSupported(keyVal) && !v2SupportedNetworks.includes(keyVal)) {
 		link = `${link}/opengov`;
 	}
 	const optionObj: DropdownMenuItemType = {

--- a/src/ui-components/QuickView.tsx
+++ b/src/ui-components/QuickView.tsx
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 import { useNetworkSelector, useUserDetailsSelector } from '~src/redux/selectors';
 import { ISocial } from '~src/auth/types';
 import ImageComponent from 'src/components/ImageComponent';
-import { network as AllNetworks } from '~src/global/networkConstants';
+import { network as AllNetworks, v2SupportedNetworks } from '~src/global/networkConstants';
 import JudgementIcon from '~assets/icons/judgement-icon.svg';
 import ShareScreenIcon from '~assets/icons/share-icon-new.svg';
 import { MinusCircleFilled } from '@ant-design/icons';
@@ -233,7 +233,7 @@ const QuickView = ({
 					/>
 				</div>
 			</div>
-			{loginUserId != userId && !!loginUserId && (
+			{loginUserId != userId && !!loginUserId && !v2SupportedNetworks.includes(network) && (
 				<div className='mt-2 flex justify-between gap-2'>
 					{!TippingUnavailableNetworks.includes(network) && (
 						<Tooltip


### PR DESCRIPTION
- Replaced references to 'revampedNetworks' with 'v2SupportedNetworks' across multiple components and pages to standardize network checks.
- Updated conditional rendering logic to ensure UI elements are displayed correctly based on the supported network.
- Enhanced server-side props handling to redirect users from v2 supported networks appropriately.
- Adjusted imports in various files to include the new 'v2SupportedNetworks' constant for improved maintainability.