### PR TITLE
kusama old conditions

### DIFF
--- a/src/api-utils/index.ts
+++ b/src/api-utils/index.ts
@@ -119,6 +119,8 @@ export function getNetworkFromReqHeaders(headers: IncomingHttpHeaders) {
 			network = 'moonriver';
 		} else if (network == 'polkadot-old') {
 			network = 'polkadot';
+		} else if (network == 'kusama-old') {
+			network = 'kusama';
 		} else {
 			network = process.env.NEXT_PUBLIC_APP_ENV === 'development' ? defaultNetwork : network;
 		}

--- a/src/global/defaultNetwork.ts
+++ b/src/global/defaultNetwork.ts
@@ -9,6 +9,9 @@ export const defaultNetwork = (() => {
 		if (hostname.startsWith('polkadot-old.')) {
 			return 'polkadot';
 		}
+		if (hostname.startsWith('kusama-old.')) {
+			return 'kusama';
+		}
 	}
 
 	const defaultNetwork = process.env.NEXT_PUBLIC_DEFAULT_NETWORK;

--- a/src/util/getNetwork.ts
+++ b/src/util/getNetwork.ts
@@ -43,6 +43,8 @@ export default function getNetwork(): Network {
 		network = 'moonbase';
 	} else if (network == 'polkadot-old') {
 		network = 'polkadot';
+	} else if (network == 'kusama-old') {
+		network = 'kusama';
 	}
 
 	if (!possibleNetworks.includes(network)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly recognize kusama-old hostnames and map them to the Kusama network.
  - Ensures consistent network detection across API requests, default network selection, and URL/query parsing.
  - Reduces misrouting and errors when accessing legacy kusama-old domains.
  - Improves reliability for users navigating via old bookmarks or links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->