### PR TITLE
feat: add treasury categories to post creation and display

### DIFF
--- a/src/components/Post/CreatePost/index.tsx
+++ b/src/components/Post/CreatePost/index.tsx
@@ -205,6 +205,7 @@ const CreatePost = ({ className, proposalType }: Props) => {
 		setGovType(cacheObj.govType || 'gov_1');
 		setTopicId(Number(cacheObj.topicId) || 2);
 		setTags(JSON.parse(cacheObj.tags || '[]'));
+		setSelectedCategories(JSON.parse(cacheObj.selectedCategories || '[]'));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -311,7 +312,10 @@ const CreatePost = ({ className, proposalType }: Props) => {
 								mode='multiple'
 								allowClear
 								placeholder='Select treasury categories'
-								onChange={(value) => setSelectedCategories(value)}
+								onChange={(value) => {
+									setSelectedCategories(value);
+									savePostFormCacheValue('selectedCategories', JSON.stringify(value));
+								}}
 								value={selectedCategories}
 								className='dark:bg-transparent'
 							>

--- a/src/components/Post/CreatePost/index.tsx
+++ b/src/components/Post/CreatePost/index.tsx
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Form, Switch } from 'antd';
+import { Form, Switch, Select } from 'antd';
 import { useRouter } from 'next/router';
 import React, { useEffect, useRef, useState } from 'react';
 import { PostCategory } from 'src/global/post_categories';
@@ -12,6 +12,7 @@ import BackToListingView from 'src/ui-components/BackToListingView';
 import ErrorAlert from 'src/ui-components/ErrorAlert';
 import queueNotification from 'src/ui-components/QueueNotification';
 import styled from 'styled-components';
+import { TREASURY_CATEGORIES } from '~src/global/treasuryCategories';
 
 import { ChangeResponseType, CreatePostResponseType } from '~src/auth/types';
 import POLL_TYPE from '~src/global/pollTypes';
@@ -41,6 +42,7 @@ const CreatePost = ({ className, proposalType }: Props) => {
 	const router = useRouter();
 	const currentUser = useUserDetailsSelector();
 	const { network } = useNetworkSelector();
+	const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
 
 	const [form] = Form.useForm();
 	const pollEndBlock = usePollEndBlock();
@@ -141,6 +143,7 @@ const CreatePost = ({ className, proposalType }: Props) => {
 				tags,
 				title,
 				topicId,
+				treasury_categories: selectedCategories,
 				userId: currentUser.id
 			});
 
@@ -301,6 +304,29 @@ const CreatePost = ({ className, proposalType }: Props) => {
 						setTags={setTags}
 						onChange={(arr) => savePostFormCacheValue('tags', JSON.stringify(arr))}
 					/>
+
+					<div className='mt-6'>
+						<Form.Item label={<span className='text-sm font-normal tracking-wide text-sidebarBlue dark:text-white'>Treasury Category (Optional)</span>}>
+							<Select
+								mode='multiple'
+								allowClear
+								placeholder='Select treasury categories'
+								onChange={(value) => setSelectedCategories(value)}
+								value={selectedCategories}
+								className='dark:bg-transparent'
+							>
+								{TREASURY_CATEGORIES.map((category) => (
+									<Select.Option
+										key={category}
+										value={category}
+									>
+										{category}
+									</Select.Option>
+								))}
+							</Select>
+						</Form.Item>
+					</div>
+
 					{/* who can comment */}
 					<AllowedCommentorsRadioButtons
 						className='mt-8 gap-2'

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -24,6 +24,7 @@ import getNetwork from '~src/util/getNetwork';
 import nextApiClientFetch from '~src/util/nextApiClientFetch';
 import { IVerified } from '~src/auth/types';
 import Link from 'next/link';
+import { Tag } from 'antd';
 import LinkCard from './LinkCard';
 import { IDataType, IDataVideoType } from './Tabs/PostTimeline/Audit';
 import styled from 'styled-components';
@@ -568,6 +569,7 @@ const Post: FC<IPostProps> = (props) => {
 					topic: post?.topic || '',
 					track_name: trackName,
 					track_number: post?.track_number,
+					treasury_categories: post?.treasury_categories || [],
 					userId: post?.user_id,
 					username: post?.username
 				}}
@@ -628,6 +630,19 @@ const Post: FC<IPostProps> = (props) => {
 												postArguments={post?.proposed_call?.args}
 												className='mb-5'
 											/>
+											{post?.treasury_categories && post.treasury_categories.length > 0 && (
+												<div className='mb-6 flex flex-wrap gap-2'>
+													{post.treasury_categories.map((category: string) => (
+														<Tag
+															color='cyan'
+															key={category}
+															className='m-0 border-cyan-400 bg-cyan-50 text-cyan-600 dark:border-cyan-800 dark:bg-cyan-950 dark:text-cyan-400'
+														>
+															{category.replace('_', ' ')}
+														</Tag>
+													))}
+												</div>
+											)}
 											<Tabs
 												theme={theme}
 												type='card'

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -638,7 +638,7 @@ const Post: FC<IPostProps> = (props) => {
 															key={category}
 															className='m-0 border-cyan-400 bg-cyan-50 text-cyan-600 dark:border-cyan-800 dark:bg-cyan-950 dark:text-cyan-400'
 														>
-															{category.replace('_', ' ')}
+															{category}
 														</Tag>
 													))}
 												</div>

--- a/src/global/treasuryCategories.ts
+++ b/src/global/treasuryCategories.ts
@@ -1,0 +1,14 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+export const TREASURY_CATEGORIES = [
+	'Software Development',
+	'Events & Outreach',
+	'Research',
+	'Security & Audits',
+	'Marketing & PR',
+	'Tooling & Infrastructure',
+	'Educational Content',
+	'Other'
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -406,6 +406,7 @@ export interface Post {
 	link?: string;
 	updated_at?: Date;
 	isSpamDetected?: boolean;
+	treasury_categories?: string[];
 }
 
 export interface IPostTag {


### PR DESCRIPTION
## Description
Adds a list of Treasury categories to discussion and submission posts to improve reviewer visibility.

Resolves https://github.com/polkassembly/polkassembly.github.io/issues/32

## Changes Made
- Added global constants for Polkadot Treasury categories.
- Updated Post data context to support `treasury_categories`.
- Added a multi-select dropdown in the Post Creation form.
- Displayed selected categories using Cyan Ant Design tags in the Post view.
- Fixed linting errors (alphabetical sorting and missing headers).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (verified with npx next lint)

@anaelleparity The UI implementation for treasury categories is ready for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select multiple treasury categories when creating a post.
  * Treasury categories are shown as tags on posts.
  * Available categories: Software Development; Events & Outreach; Research; Security & Audits; Marketing & PR; Tooling & Infrastructure; Educational Content; Other.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polkassembly/polkassembly/pull/2418)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->